### PR TITLE
Added Favorites button to Explorer dialog dockable menu.

### DIFF
--- a/Explorer/src/ExplorerDialog.cpp
+++ b/Explorer/src/ExplorerDialog.cpp
@@ -125,7 +125,7 @@ static ToolBarButtonUnit toolBarIcons[] = {
     {IDM_EX_FOLDER_NEW,		IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON, IDB_EX_FOLDERNEW, 0},
 	{IDM_EX_SEARCH_FIND,	IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON, IDB_EX_FIND, 0},
 	{IDM_EX_GO_TO_FOLDER,	IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON, IDB_EX_FOLDERGO, 0},
-
+    {IDM_EX_FAVORITES,		IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON, IDB_TB_FAVES, 0},
 	//-------------------------------------------------------------------------------------//
 	{0,						IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON, IDI_SEPARATOR_ICON, 0},
 	//-------------------------------------------------------------------------------------//
@@ -147,6 +147,7 @@ static ToolBarButtonUnit toolBarIconsNT[] = {
 	{IDM_EX_SEARCH_FIND,	IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON, IDB_EX_FIND, 0},
 	{IDM_EX_GO_TO_USER,		IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON, IDB_EX_FOLDERUSER, 0},
 	{IDM_EX_GO_TO_FOLDER,	IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON, IDB_EX_FOLDERGO, 0},
+    {IDM_EX_FAVORITES,		IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON, IDB_TB_FAVES, 0},
 
 	//-------------------------------------------------------------------------------------//
 	{0,						IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON,		IDI_SEPARATOR_ICON, IDI_SEPARATOR_ICON, 0},
@@ -166,6 +167,7 @@ static LPCTSTR szToolTip[23] = {
 	_T("Find in Files..."),
 	_T("Folder of Current File"),
 	_T("User Folder"),
+	_T("Favorites"),
 	_T("Refresh")
 };
 
@@ -1189,6 +1191,9 @@ void ExplorerDialog::tb_cmd(WPARAM message)
 			break;
 		case IDM_EX_GO_TO_FOLDER:
 			gotoCurrentFile();
+			break;
+		case IDM_EX_FAVORITES:
+			showFavesDialog();
 			break;
 		case IDM_EX_UPDATE:
 		{

--- a/Explorer/src/ExplorerResource.h
+++ b/Explorer/src/ExplorerResource.h
@@ -68,12 +68,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 	#define	IDM_EX_SEARCH_FIND				(IDM_TOOLBAR + 5)
 	#define	IDM_EX_GO_TO_FOLDER				(IDM_TOOLBAR + 6)
 	#define	IDM_EX_GO_TO_USER				(IDM_TOOLBAR + 7)
-	#define IDM_EX_UPDATE					(IDM_TOOLBAR + 8)
-	#define	IDM_EX_LINK_NEW_FILE			(IDM_TOOLBAR + 9)
-	#define	IDM_EX_LINK_NEW_FOLDER			(IDM_TOOLBAR + 10)
-	#define	IDM_EX_LINK_NEW 				(IDM_TOOLBAR + 11)
-	#define IDM_EX_LINK_DELETE				(IDM_TOOLBAR + 12)
-	#define	IDM_EX_LINK_EDIT				(IDM_TOOLBAR + 13)
+	#define	IDM_EX_FAVORITES				(IDM_TOOLBAR + 8)
+	#define IDM_EX_UPDATE					(IDM_TOOLBAR + 9)
+	#define	IDM_EX_LINK_NEW_FILE			(IDM_TOOLBAR + 10)
+	#define	IDM_EX_LINK_NEW_FOLDER			(IDM_TOOLBAR + 11)
+	#define	IDM_EX_LINK_NEW 				(IDM_TOOLBAR + 12)
+	#define IDM_EX_LINK_DELETE				(IDM_TOOLBAR + 13)
+	#define	IDM_EX_LINK_EDIT				(IDM_TOOLBAR + 14)
 
 
 


### PR DESCRIPTION
I'd like a quick way to access the Favorites dialog (which I only open when needed) from the Explorer dialog dockable (which I always have open).  This small PR adds a "Favorites" button with the Favorites icon to the small menu on the top of the Explorer dialog dockable.

Please consider adding this pull request to the next release.

Cheers.
