### PR TITLE
Use Github Actions to automate build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+ # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
           name: Explorer-${{ matrix.build_configuration }}-${{ matrix.build_platform }}
-          path: ${{ matrix.build_configuration }}\${{ matrix.build_platform }}\Explorer.dll
+          path: $(OutDir)$(TargetName)$(TargetExt)
 
     - name: Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -36,8 +36,8 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/') && matrix.build_configuration == 'Release'
       with:
           body: ${{ github.event.commits[0].message }}
-          files: ${{ matrix.build_configuration }}/${{ matrix.build_platform }}/Explorer-v${{ github.ref_name }}-${{ matrix.build_platform }}.zip
+          files: build/bin/${{ matrix.build_platform }}/${{ matrix.build_configuration }}/Explorer-v${{ github.ref_name }}-${{ matrix.build_platform }}.zip
 
     - name: SHA256
       if: startsWith(github.ref, 'refs/tags/') && matrix.build_configuration == 'Release'
-      run: sha256sum.exe ${{ matrix.build_configuration }}\${{ matrix.build_platform }}\Explorer-v${{ github.ref_name }}-${{ matrix.build_platform }}.zip
+      run: sha256sum.exe build\bin\${{ matrix.build_platform }}\${{ matrix.build_configuration }}\Explorer-v${{ github.ref_name }}-${{ matrix.build_platform }}.zip

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 6
       matrix:
         build_configuration: [Release, Debug]
-        build_platform: [x64, Win32]
+        build_platform: [x64, x86]
 
     steps:
     - name: Checkout repo

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 6
       matrix:
         build_configuration: [Release, Debug]
-        build_platform: [x64, Win32, ARM64]
+        build_platform: [x64, Win32]
 
     steps:
     - name: Checkout repo

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
           name: Explorer-${{ matrix.build_configuration }}-${{ matrix.build_platform }}
-          path: $(OutDir)$(TargetName)$(TargetExt)
+          path: build\bin\${{ matrix.build_platform }}\${{ matrix.build_configuration }}\Explorer.dll
 
     - name: Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: MSBuild of plugin dll
       working-directory: .\
-      run: msbuild Explorer.vcxproj /m /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}" /p:PlatformToolset="v143" /target:zip
+      run: msbuild Explorer.vcxproj /m /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}" /p:PlatformToolset="v143" /p:PostBuildEventUseInBuild=false /target:zip
       env:
           ZIPCMD: 7z a -tzip
 

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -1,0 +1,43 @@
+name: CI_build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 6
+      matrix:
+        build_configuration: [Release, Debug]
+        build_platform: [x64, Win32, ARM64]
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1
+
+    - name: MSBuild of plugin dll
+      working-directory: .\
+      run: msbuild Explorer.vcxproj /m /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}" /p:PlatformToolset="v142" /target:zip
+      env:
+          ZIPCMD: 7z a -tzip
+
+    - name: Archive
+      uses: actions/upload-artifact@v3
+      with:
+          name: Explorer-${{ matrix.build_configuration }}-${{ matrix.build_platform }}
+          path: ${{ matrix.build_configuration }}\${{ matrix.build_platform }}\Explorer.dll
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/') && matrix.build_configuration == 'Release'
+      with:
+          body: ${{ github.event.commits[0].message }}
+          files: ${{ matrix.build_configuration }}/${{ matrix.build_platform }}/Explorer-v${{ github.ref_name }}-${{ matrix.build_platform }}.zip
+
+    - name: SHA256
+      if: startsWith(github.ref, 'refs/tags/') && matrix.build_configuration == 'Release'
+      run: sha256sum.exe ${{ matrix.build_configuration }}\${{ matrix.build_platform }}\Explorer-v${{ github.ref_name }}-${{ matrix.build_platform }}.zip

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: MSBuild of plugin dll
       working-directory: .\
-      run: msbuild Explorer.vcxproj /m /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}" /p:PlatformToolset="v142" /target:zip
+      run: msbuild Explorer.vcxproj /m /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}" /p:PlatformToolset="v143" /target:zip
       env:
           ZIPCMD: 7z a -tzip
 

--- a/Explorer.vcxproj.user
+++ b/Explorer.vcxproj.user
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+    Rename PROJECTNAME to the same as the *.vcxproj file in your project.
+
+    Or, import into that file by adding before the last closing tag:
+
+    <Import Project="PROJECTNAME.vcxproj.user"/>
+
+    Then, call with:
+
+      msbuild /target:zip
+
+    You can customize the ZIP program by setting the environment variable:
+
+      set ZIPCMD=zip
+      set ZIPCMD=7z a -tzip
+  -->
+
+  <Target Name="Zip" DependsOnTargets="Build">
+    <PropertyGroup>
+        <ZipCmd Condition="'$(ZIPCMD)' == ''">zip</ZipCmd>
+    </PropertyGroup>
+    <Exec Command="if not exist $(OutDir)$(TargetName) mkdir $(OutDir)$(TargetName)"/>
+    <Exec Command="copy $(OutDir)$(TargetName)$(TargetExt) $(OutDir)$(TargetName)"/>
+    <Exec Command="for /f %%i in ('powershell -NoProfile -Command &quot;(Get-Item $(OutDir)$(TargetName)$(TargetExt)).VersionInfo.ProductVersion&quot;') do del $(OutDir)$(TargetName)-v%%i-$(Platform).zip"/>
+    <Exec Command="for /f %%i in ('powershell -NoProfile -Command &quot;(Get-Item $(OutDir)$(TargetName)$(TargetExt)).VersionInfo.ProductVersion&quot;') do cd  $(OutDir)$(TargetName) %26%26 $(ZIPCMD) -r ..\$(TargetName)-v%%i-$(Platform).zip *"/>
+  </Target>
+</Project>


### PR DESCRIPTION
Fix #75 

Any `git push` will now result in both "Release" and "Debug" configuration artifacts built for both "x64" and "x86" platforms.

See examples:
https://github.com/vinsworldcom/npp-explorer-plugin/actions

You can also when happy with a new release, use:

`git tag 1.8.2.31 main`

for example, and then:

`git push origin 1.8.2.31`

to auto-create a new release with ZIP'd versions of both the Release x64 and Release x86 artifacts and the Github Action will also show the SHA256 signature of the ZIP file - in case you ever want to add to the Notepad++ plugin list.

- [.github/workflows/CI_build.yml](https://github.com/funap/npp-explorer-plugin/pull/76/files#diff-f1f3205c400170ee27a9f6cce59215a9cb0179d6491af8fd3942dcf40fb238ff)
Does all the work of Github Actions building the Release and Debug artifacts for the platforms x64 and x86.

- [Explorer.vcxproj.user](https://github.com/funap/npp-explorer-plugin/pull/76/files#diff-0523d1cd495461982efd8c9efa09d896e3f49de7c77d1609b551f131576d8e47)
Creates the "zip" target that is used in the automated build process so we can ZIP the DLLs into the proper archive for distribution.


Cheers.

