### PR TITLE
Implement FileSystemService and refactor disk I/O operations

### DIFF
--- a/Explorer.vcxproj
+++ b/Explorer.vcxproj
@@ -252,6 +252,7 @@
     <ClCompile Include="src\Explorer\FileDlg.cpp" />
     <ClCompile Include="src\Explorer\FileFilter.cpp" />
     <ClCompile Include="src\Explorer\FileList.cpp" />
+    <ClCompile Include="src/Explorer/FileSystemService.cpp" />
     <ClCompile Include="src\Explorer\FileSystemWatcher.cpp" />
     <ClCompile Include="src\Explorer\FuzzyMatcher.cpp" />
     <ClCompile Include="src\Explorer\HelpDialog.cpp" />
@@ -293,6 +294,7 @@
     <ClInclude Include="src\Explorer\FileDlg.h" />
     <ClInclude Include="src\Explorer\FileFilter.h" />
     <ClInclude Include="src\Explorer\FileList.h" />
+    <ClInclude Include="src/Explorer/FileSystemService.h" />
     <ClInclude Include="src\Explorer\FileSystemWatcher.h" />
     <ClInclude Include="src\Explorer\FuzzyMatcher.h" />
     <ClInclude Include="src\Explorer\HelpDialog.h" />

--- a/Explorer.vcxproj
+++ b/Explorer.vcxproj
@@ -252,7 +252,7 @@
     <ClCompile Include="src\Explorer\FileDlg.cpp" />
     <ClCompile Include="src\Explorer\FileFilter.cpp" />
     <ClCompile Include="src\Explorer\FileList.cpp" />
-    <ClCompile Include="src/Explorer/FileSystemService.cpp" />
+    <ClCompile Include="src\Explorer\FileSystemService.cpp" />
     <ClCompile Include="src\Explorer\FileSystemWatcher.cpp" />
     <ClCompile Include="src\Explorer\FuzzyMatcher.cpp" />
     <ClCompile Include="src\Explorer\HelpDialog.cpp" />
@@ -294,7 +294,7 @@
     <ClInclude Include="src\Explorer\FileDlg.h" />
     <ClInclude Include="src\Explorer\FileFilter.h" />
     <ClInclude Include="src\Explorer\FileList.h" />
-    <ClInclude Include="src/Explorer/FileSystemService.h" />
+    <ClInclude Include="src\Explorer\FileSystemService.h" />
     <ClInclude Include="src\Explorer\FileSystemWatcher.h" />
     <ClInclude Include="src\Explorer\FuzzyMatcher.h" />
     <ClInclude Include="src\Explorer\HelpDialog.h" />

--- a/Explorer.vcxproj.filters
+++ b/Explorer.vcxproj.filters
@@ -108,9 +108,6 @@
     <ClCompile Include="src\Explorer\Settings.cpp">
       <Filter>src\Explorer</Filter>
     </ClCompile>
-    <ClCompile Include="src\Explorer\FileSystemService.cpp">
-      <Filter>src\Explorer</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="src\Explorer\version.rc">
@@ -254,9 +251,6 @@
       <Filter>src\Explorer</Filter>
     </ClInclude>
     <ClInclude Include="src\Explorer\Settings.h">
-      <Filter>src\Explorer</Filter>
-    </ClInclude>
-    <ClInclude Include="src\Explorer\FileSystemService.h">
       <Filter>src\Explorer</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Explorer.vcxproj.filters
+++ b/Explorer.vcxproj.filters
@@ -108,6 +108,9 @@
     <ClCompile Include="src\Explorer\Settings.cpp">
       <Filter>src\Explorer</Filter>
     </ClCompile>
+    <ClCompile Include="src\Explorer\FileSystemService.cpp">
+      <Filter>src\Explorer</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="src\Explorer\version.rc">
@@ -251,6 +254,9 @@
       <Filter>src\Explorer</Filter>
     </ClInclude>
     <ClInclude Include="src\Explorer\Settings.h">
+      <Filter>src\Explorer</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Explorer\FileSystemService.h">
       <Filter>src\Explorer</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/Explorer/Explorer.cpp
+++ b/src/Explorer/Explorer.cpp
@@ -484,7 +484,7 @@ bool IsValidFolder(const WIN32_FIND_DATA & Find)
     return (Find.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
         && (!(Find.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) || settings.IsShowHidden())
         && (_tcscmp(Find.cFileName, L".") != 0)
-        && (_tcscmp(Find.cFileName, L"..") != 0) 
+        && (_tcscmp(Find.cFileName, L"..") != 0)
         && (Find.cFileName[0] != '?');
 }
 
@@ -500,67 +500,6 @@ bool IsValidFile(const WIN32_FIND_DATA & Find)
         && (!(Find.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) || settings.IsShowHidden());
 }
 
-BOOL HaveChildren(const std::wstring &folderPath)
-{
-    std::wstring searchPath = folderPath;
-    if (searchPath.back() != '\\') {
-        searchPath.append(L"\\");
-    }
-    /* add wildcard */
-    searchPath.append(L"*");
-
-    WIN32_FIND_DATA findData{};
-    HANDLE hFind = ::FindFirstFile(searchPath.c_str(), &findData);
-    if (hFind == INVALID_HANDLE_VALUE) {
-        return FALSE;
-    }
-
-    BOOL bFound = TRUE;
-    BOOL bRet = FALSE;
-    do {
-        if (IsValidFolder(findData) == TRUE) {
-            bFound = FALSE;
-            bRet = TRUE;
-            break;
-        }
-        if (settings.IsUseFullTree() && IsValidFile(findData) == TRUE) {
-            bFound = FALSE;
-            bRet = TRUE;
-            break;
-        }
-
-    } while ((FindNextFile(hFind, &findData)) && (bFound == TRUE));
-
-    ::FindClose(hFind);
-
-    return bRet;
-}
-
-BOOL ConvertNetPathName(LPCTSTR pPathName, LPTSTR pRemotePath, UINT length)
-{
-    DWORD driveList      = ::GetLogicalDrives();
-    WCHAR volumeName[MAX_PATH];
-    WCHAR remoteName[MAX_PATH];
-
-    for (INT i = 0; i < 26; ++i) {
-        if (0x01 & (driveList >> i)) {
-            _stprintf(volumeName, L"%c:", 'A' + i);
-
-            /* call get connection twice to get the real size */
-            DWORD dwRemoteLength = 1;
-            if (ERROR_MORE_DATA == WNetGetConnection(volumeName, remoteName, &dwRemoteLength)) {
-                if ((dwRemoteLength < MAX_PATH) && (NO_ERROR == WNetGetConnection(volumeName, remoteName, &dwRemoteLength))) {
-                    if (_tcsstr(pPathName, remoteName) != nullptr) {
-                        wcscpy(pRemotePath, volumeName);
-                        _tcsncat(pRemotePath, &pPathName[dwRemoteLength - 1], length - 2);
-                        return TRUE;
-                    }
-                }
-            }
-        }
-    }
-    return FALSE;
-}
 
 // Get system images
 HIMAGELIST GetSmallImageList(BOOL bSystem)
@@ -700,42 +639,6 @@ void ExtractIcons(LPCTSTR currentPath, LPCTSTR fileName, DevType type, LPINT piI
     }
 }
 
-// Resolve files if they are shortcuts
-HRESULT ResolveShortCut(const std::wstring &shortcutPath, LPWSTR lpszFilePath, int maxBuf)
-{
-    Microsoft::WRL::ComPtr<IShellLink> shellLink;
-    HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&shellLink));
-    if (FAILED(hr)) {
-        return hr;
-    }
-
-    Microsoft::WRL::ComPtr<IPersistFile> persistFile;
-    hr = shellLink.As(&persistFile);
-    if (FAILED(hr)) {
-        return hr;
-    }
-
-    hr = persistFile->Load(shortcutPath.c_str(), STGM_READ);
-    if (FAILED(hr)) {
-        return hr;
-    }
-
-    hr = shellLink->Resolve(nullptr, SLR_UPDATE);
-    if (FAILED(hr)) {
-        return hr;
-    }
-
-    hr = shellLink->GetPath(lpszFilePath, maxBuf, nullptr, SLGP_RAWPATH);
-    if (FAILED(hr)) {
-        return hr;
-    }
-
-    if (::PathIsDirectory(lpszFilePath) && lpszFilePath[wcslen(lpszFilePath) - 1] != L'\\') {
-        wcsncat_s(lpszFilePath, maxBuf, L"\\", 1);
-    }
-
-    return S_OK;
-}
 
 
 // Current docs

--- a/src/Explorer/Explorer.h
+++ b/src/Explorer/Explorer.h
@@ -110,8 +110,6 @@ bool IsValidFile(const WIN32_FIND_DATA & Find);
 HIMAGELIST GetSmallImageList(BOOL bSystem);
 void ExtractIcons(LPCTSTR currentPath, LPCTSTR fileName, DevType type, LPINT iIconNormal, LPINT iIconSelected, LPINT iIconOverlayed);
 
-/* Resolve Links */
-
 /* current open files */
 void UpdateDocs();
 void UpdateCurrUsedDocs(LPTSTR *ppFiles, UINT numFiles);

--- a/src/Explorer/Explorer.h
+++ b/src/Explorer/Explorer.h
@@ -105,8 +105,6 @@ bool IsValidFileName(LPTSTR pszFileName);
 bool IsValidFolder(const WIN32_FIND_DATA & Find);
 bool IsValidParentFolder(const WIN32_FIND_DATA & Find);
 bool IsValidFile(const WIN32_FIND_DATA & Find);
-BOOL HaveChildren(const std::wstring &folderPath);
-BOOL ConvertNetPathName(LPCTSTR pPathName, LPTSTR pRemotePath, UINT length);
 
 /* Get Image Lists */
 HIMAGELIST GetSmallImageList(BOOL bSystem);

--- a/src/Explorer/Explorer.h
+++ b/src/Explorer/Explorer.h
@@ -111,7 +111,6 @@ HIMAGELIST GetSmallImageList(BOOL bSystem);
 void ExtractIcons(LPCTSTR currentPath, LPCTSTR fileName, DevType type, LPINT iIconNormal, LPINT iIconSelected, LPINT iIconOverlayed);
 
 /* Resolve Links */
-HRESULT ResolveShortCut(const std::wstring& shortcutPath, LPWSTR lpszFilePath, int maxBuf);
 
 /* current open files */
 void UpdateDocs();

--- a/src/Explorer/Explorer.h
+++ b/src/Explorer/Explorer.h
@@ -110,6 +110,8 @@ bool IsValidFile(const WIN32_FIND_DATA & Find);
 HIMAGELIST GetSmallImageList(BOOL bSystem);
 void ExtractIcons(LPCTSTR currentPath, LPCTSTR fileName, DevType type, LPINT iIconNormal, LPINT iIconSelected, LPINT iIconOverlayed);
 
+/* Resolve Links */
+
 /* current open files */
 void UpdateDocs();
 void UpdateCurrUsedDocs(LPTSTR *ppFiles, UINT numFiles);

--- a/src/Explorer/ExplorerDialog.cpp
+++ b/src/Explorer/ExplorerDialog.cpp
@@ -771,7 +771,7 @@ void ExplorerDialog::tb_cmd(WPARAM message)
                     }
                     newFilePath /= szFileName;
 
-                    if (SUCCEEDED(FileSystemService::Instance().CreateNewFile(newFilePath.wstring()))) {
+                    if (FileSystemService::Instance().CreateNewFile(newFilePath.wstring())) {
                         ::SendMessage(_hParent, NPPM_DOOPEN, 0, (LPARAM)newFilePath.c_str());
                     }
                     break;
@@ -1096,7 +1096,7 @@ BOOL ExplorerDialog::SelectItem(const std::filesystem::path& path)
         WCHAR szLongPath[MAX_PATH] = {};
         std::wstring remotePath;
         /* convert possible net path name and get the full path name for compare */
-        if (FileSystemService::Instance().ConvertNetPathName(path.wstring(), remotePath) == TRUE) {
+        if (FileSystemService::Instance().ConvertNetPathName(path.wstring(), remotePath)) {
             ::GetLongPathName(remotePath.c_str(), szLongPath, MAX_PATH);
         }
         else {
@@ -2068,7 +2068,7 @@ void ExplorerDialog::Open(const std::wstring &path)
 
         /* open possible link */
         std::wstring resolvedPath;
-        if (SUCCEEDED(FileSystemService::Instance().ResolveShortCut(filePath, resolvedPath))) {
+        if (FileSystemService::Instance().ResolveShortCut(filePath, resolvedPath)) {
             if (::PathIsDirectory(resolvedPath.c_str()) != FALSE) {
                 SelectItem(resolvedPath);
             }

--- a/src/Explorer/ExplorerDialog.cpp
+++ b/src/Explorer/ExplorerDialog.cpp
@@ -771,7 +771,7 @@ void ExplorerDialog::tb_cmd(WPARAM message)
                     }
                     newFilePath /= szFileName;
 
-                    if (FileSystemService::Instance().CreateNewFile(newFilePath.wstring())) {
+                    if (FileSystemService::CreateNewFile(newFilePath.wstring())) {
                         ::SendMessage(_hParent, NPPM_DOOPEN, 0, (LPARAM)newFilePath.c_str());
                     }
                     break;
@@ -801,7 +801,7 @@ void ExplorerDialog::tb_cmd(WPARAM message)
                     }
                     newFolderPath /= szFolderName;
 
-                    if (FileSystemService::Instance().CreateNewDirectory(newFolderPath.wstring()) == false) {
+                    if (FileSystemService::CreateNewDirectory(newFolderPath.wstring()) == false) {
                         ::MessageBox(_hParent, L"Folder couldn't be created.", L"Error", MB_OK);
                     }
                     break;
@@ -1096,7 +1096,7 @@ BOOL ExplorerDialog::SelectItem(const std::filesystem::path& path)
         WCHAR szLongPath[MAX_PATH] = {};
         std::wstring remotePath;
         /* convert possible net path name and get the full path name for compare */
-        if (FileSystemService::Instance().ConvertNetPathName(path.wstring(), remotePath)) {
+        if (FileSystemService::ConvertNetPathName(path.wstring(), remotePath)) {
             ::GetLongPathName(remotePath.c_str(), szLongPath, MAX_PATH);
         }
         else {
@@ -1347,7 +1347,7 @@ void ExplorerDialog::onDelete(bool immediate)
         path.pop_back();
     }
 
-    FileSystemService::Instance().DeleteFiles(_hParent, { path }, immediate);
+    FileSystemService::DeleteFiles(_hParent, { path }, immediate);
 }
 
 void ExplorerDialog::onCut()
@@ -1405,7 +1405,7 @@ void ExplorerDialog::onPaste()
  */
 void ExplorerDialog::UpdateRoots()
 {
-    auto drives = FileSystemService::Instance().GetLogicalDrives();
+    auto drives = FileSystemService::GetLogicalDrives();
 
     HTREEITEM hCurrentItem = _hTreeCtrl.GetNextItem(TVI_ROOT, TVGN_CHILD);
 
@@ -1417,13 +1417,13 @@ void ExplorerDialog::UpdateRoots()
         auto it = std::find(drives.begin(), drives.end(), drivePath);
 
         if (it != drives.end()) {
-            auto volumeInfo = FileSystemService::Instance().GetVolumeName(drivePath);
+            auto volumeInfo = FileSystemService::GetVolumeName(drivePath);
             std::wstring volumeName = std::format(L"{}:", driveLetter);
             bool haveChildren = false;
 
             if (volumeInfo) {
                 volumeName = std::format(L"{}: [{}]", driveLetter, *volumeInfo);
-                haveChildren = FileSystemService::Instance().HaveChildren(drivePath, _pSettings->IsUseFullTree(), _pSettings->IsShowHidden());
+                haveChildren = FileSystemService::HaveChildren(drivePath, _pSettings->IsUseFullTree(), _pSettings->IsShowHidden());
             }
 
             if (hCurrentItem != nullptr) {
@@ -1522,7 +1522,7 @@ HTREEITEM ExplorerDialog::InsertChildFolder(const std::wstring& childFolderName,
     /* look if children test id allowed */
     BOOL haveChildren = FALSE;
     if (bChildrenTest == TRUE) {
-        haveChildren = FileSystemService::Instance().HaveChildren(path, _pSettings->IsUseFullTree(), _pSettings->IsShowHidden());
+        haveChildren = FileSystemService::HaveChildren(path, _pSettings->IsUseFullTree(), _pSettings->IsShowHidden());
     }
 
     /* insert item */
@@ -1565,7 +1565,7 @@ void ExplorerDialog::UpdateChildren(const std::wstring& path, HTREEITEM parentIt
         return;
     }
 
-    auto entries = FileSystemService::Instance().GetDirectoryEntries(path, _pSettings->IsShowHidden());
+    auto entries = FileSystemService::GetDirectoryEntries(path, _pSettings->IsShowHidden());
 
     if (!entries.empty()) {
         std::vector<FileSystemEntry> folders;
@@ -1621,7 +1621,7 @@ void ExplorerDialog::UpdateChildren(const std::wstring& path, HTREEITEM parentIt
 
                     /* update icons and expandable information */
                     std::wstring currentPath = GetPath(hCurrentItem);
-                    BOOL haveChildren = FileSystemService::Instance().HaveChildren(currentPath, _pSettings->IsUseFullTree(), _pSettings->IsShowHidden());
+                    BOOL haveChildren = FileSystemService::HaveChildren(currentPath, _pSettings->IsUseFullTree(), _pSettings->IsShowHidden());
 
                     /* get icons and update item */
                     INT iIconNormal = 0;
@@ -1660,7 +1660,7 @@ void ExplorerDialog::FetchChildren(HTREEITEM parentItem)
 {
     auto parentFolderPath = GetPath(parentItem);
 
-    auto entries = FileSystemService::Instance().GetDirectoryEntries(parentFolderPath, _pSettings->IsShowHidden());
+    auto entries = FileSystemService::GetDirectoryEntries(parentFolderPath, _pSettings->IsShowHidden());
 
     if (!entries.empty()) {
         std::vector<FileSystemEntry> folders;
@@ -2068,7 +2068,7 @@ void ExplorerDialog::Open(const std::wstring &path)
 
         /* open possible link */
         std::wstring resolvedPath;
-        if (FileSystemService::Instance().ResolveShortCut(filePath, resolvedPath)) {
+        if (FileSystemService::ResolveShortCut(filePath, resolvedPath)) {
             if (::PathIsDirectory(resolvedPath.c_str()) != FALSE) {
                 SelectItem(resolvedPath);
             }

--- a/src/Explorer/ExplorerDialog.cpp
+++ b/src/Explorer/ExplorerDialog.cpp
@@ -1565,7 +1565,7 @@ void ExplorerDialog::UpdateChildren(const std::wstring& path, HTREEITEM parentIt
         return;
     }
 
-    auto entries = FileSystemService::Instance().GetDirectoryEntries(path, _pSettings->IsUseFullTree(), _pSettings->IsShowHidden());
+    auto entries = FileSystemService::Instance().GetDirectoryEntries(path, _pSettings->IsShowHidden());
 
     if (!entries.empty()) {
         std::vector<FileSystemEntry> folders;
@@ -1573,20 +1573,20 @@ void ExplorerDialog::UpdateChildren(const std::wstring& path, HTREEITEM parentIt
 
         /* find folders */
         for (const auto& entry : entries) {
-            if (entry.isDirectory) {
+            if (entry.IsDirectory()) {
                 folders.push_back(entry);
             }
-            else {
+            else if (_pSettings->IsUseFullTree()) {
                 files.push_back(entry);
             }
         }
 
         /* sort data */
         std::sort(folders.begin(), folders.end(), [](const auto& lhs, const auto& rhs) {
-            return ::StrCmpLogicalW(lhs.name.c_str(), rhs.name.c_str()) < 0;
+            return ::StrCmpLogicalW(lhs.Name().c_str(), rhs.Name().c_str()) < 0;
         });
         std::sort(files.begin(), files.end(), [](const auto& lhs, const auto& rhs) {
-            return ::StrCmpLogicalW(lhs.name.c_str(), rhs.name.c_str()) < 0;
+            return ::StrCmpLogicalW(lhs.Name().c_str(), rhs.Name().c_str()) < 0;
         });
 
         /* update tree */
@@ -1595,9 +1595,9 @@ void ExplorerDialog::UpdateChildren(const std::wstring& path, HTREEITEM parentIt
                 std::wstring name = _hTreeCtrl.GetItemText(hCurrentItem);
                 if (!name.empty()) {
                     /* compare current item and the current folder name */
-                    while ((name != entry.name) && (hCurrentItem != nullptr)) {
+                    while ((name != entry.Name()) && (hCurrentItem != nullptr)) {
                         /* if it's not equal delete or add new item */
-                        if (FindFolderAfter(entry.name.c_str(), hCurrentItem) == TRUE) {
+                        if (FindFolderAfter(entry.Name().c_str(), hCurrentItem) == TRUE) {
                             HTREEITEM pPrevItem = hCurrentItem;
                             hCurrentItem = _hTreeCtrl.GetNextItem(hCurrentItem, TVGN_NEXT);
                             _hTreeCtrl.DeleteItem(pPrevItem);
@@ -1607,10 +1607,10 @@ void ExplorerDialog::UpdateChildren(const std::wstring& path, HTREEITEM parentIt
 
                             /* Note: If hCurrentItem is the first item in the list pPrevItem is nullptr */
                             if (pPrevItem == nullptr) {
-                                hCurrentItem = InsertChildFolder(entry.name, parentItem, TVI_FIRST);
+                                hCurrentItem = InsertChildFolder(entry.Name(), parentItem, TVI_FIRST);
                             }
                             else {
-                                hCurrentItem = InsertChildFolder(entry.name, parentItem, pPrevItem);
+                                hCurrentItem = InsertChildFolder(entry.Name(), parentItem, pPrevItem);
                             }
                         }
 
@@ -1629,7 +1629,7 @@ void ExplorerDialog::UpdateChildren(const std::wstring& path, HTREEITEM parentIt
                     INT iIconOverlayed = 0;
                     ExtractIcons(currentPath.c_str(), nullptr, DEVT_DIRECTORY, &iIconNormal, &iIconSelected, &iIconOverlayed);
 
-                    BOOL bHidden = ((entry.attributes & FILE_ATTRIBUTE_HIDDEN) != 0);
+                    BOOL bHidden = entry.IsHidden();
                     _hTreeCtrl.UpdateItem(hCurrentItem, name, iIconNormal, iIconSelected, iIconOverlayed, bHidden, haveChildren);
 
                     /* update recursive */
@@ -1641,7 +1641,7 @@ void ExplorerDialog::UpdateChildren(const std::wstring& path, HTREEITEM parentIt
                     hCurrentItem = _hTreeCtrl.GetNextItem(hCurrentItem, TVGN_NEXT);
                 }
                 else {
-                    hCurrentItem = InsertChildFolder(entry.name, parentItem);
+                    hCurrentItem = InsertChildFolder(entry.Name(), parentItem);
                     hCurrentItem = _hTreeCtrl.GetNextItem(hCurrentItem, TVGN_NEXT);
                 }
             }
@@ -1660,31 +1660,31 @@ void ExplorerDialog::FetchChildren(HTREEITEM parentItem)
 {
     auto parentFolderPath = GetPath(parentItem);
 
-    auto entries = FileSystemService::Instance().GetDirectoryEntries(parentFolderPath, _pSettings->IsUseFullTree(), _pSettings->IsShowHidden());
+    auto entries = FileSystemService::Instance().GetDirectoryEntries(parentFolderPath, _pSettings->IsShowHidden());
 
     if (!entries.empty()) {
         std::vector<FileSystemEntry> folders;
         std::vector<FileSystemEntry> files;
         for (const auto& entry : entries) {
-            if (entry.isDirectory) {
+            if (entry.IsDirectory()) {
                 folders.push_back(entry);
             }
-            else {
+            else if (_pSettings->IsUseFullTree()) {
                 files.push_back(entry);
             }
         }
 
         /* sort data */
         std::sort(folders.begin(), folders.end(), [](const auto& lhs, const auto& rhs) {
-            return ::StrCmpLogicalW(lhs.name.c_str(), rhs.name.c_str()) < 0;
+            return ::StrCmpLogicalW(lhs.Name().c_str(), rhs.Name().c_str()) < 0;
         });
         std::sort(files.begin(), files.end(), [](const auto& lhs, const auto& rhs) {
-            return ::StrCmpLogicalW(lhs.name.c_str(), rhs.name.c_str()) < 0;
+            return ::StrCmpLogicalW(lhs.Name().c_str(), rhs.Name().c_str()) < 0;
         });
 
         for (const auto* entries_ptr : { &folders, &files }) {
             for (const auto& entry : *entries_ptr) {
-                if (InsertChildFolder(entry.name, parentItem) == nullptr) {
+                if (InsertChildFolder(entry.Name(), parentItem) == nullptr) {
                     break;
                 }
             }

--- a/src/Explorer/ExplorerDialog.cpp
+++ b/src/Explorer/ExplorerDialog.cpp
@@ -38,6 +38,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "Editor.h"
 #include "resource.h"
 #include "ThemeRenderer.h"
+#include "FileSystemService.h"
 
 namespace {
 
@@ -113,30 +114,6 @@ LPCTSTR GetNameStrFromCmd(UINT resourceId)
     }
     return nullptr;
 }
-
-std::optional<std::wstring> GetVolumeName(LPCWSTR drivePath)
-{
-    DWORD volumeNameSize = MAX_PATH;
-    std::wstring volumeName(volumeNameSize, L'\0');
-
-    if (::GetVolumeInformation(drivePath, &volumeName[0], volumeNameSize, nullptr, nullptr, nullptr, nullptr, 0)) {
-        volumeName.resize(wcslen(volumeName.c_str()));
-        return volumeName;
-    }
-    else {
-        return std::nullopt;
-    }
-}
-
-struct FileSystemEntry {
-    std::wstring    name;
-    DWORD           attributes;
-    FileSystemEntry(const WCHAR* fileName, DWORD fileAttributes)
-        : name(fileName)
-        , attributes(fileAttributes)
-    {
-    }
-};
 
 } // namespace
 
@@ -458,7 +435,7 @@ INT_PTR CALLBACK ExplorerDialog::run_dlgProc(UINT Message, WPARAM wParam, LPARAM
     case EXM_USER_ICONBAR:
         tb_cmd(wParam);
         return TRUE;
-    case WM_TIMER: 
+    case WM_TIMER:
         if (wParam == EXT_UPDATEDEVICE) {
             ::KillTimer(_hSelf, EXT_UPDATEDEVICE);
             ::SetEvent(g_hEvent[EID_UPDATE_DEVICE]);
@@ -794,8 +771,9 @@ void ExplorerDialog::tb_cmd(WPARAM message)
                     }
                     newFilePath /= szFileName;
 
-                    ::CloseHandle(::CreateFile(newFilePath.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
-                    ::SendMessage(_hParent, NPPM_DOOPEN, 0, (LPARAM)newFilePath.c_str());
+                    if (SUCCEEDED(FileSystemService::Instance().CreateNewFile(newFilePath.wstring()))) {
+                        ::SendMessage(_hParent, NPPM_DOOPEN, 0, (LPARAM)newFilePath.c_str());
+                    }
                     break;
                 }
             }
@@ -823,7 +801,7 @@ void ExplorerDialog::tb_cmd(WPARAM message)
                     }
                     newFolderPath /= szFolderName;
 
-                    if (::CreateDirectory(newFolderPath.c_str(), nullptr) == FALSE) {
+                    if (FileSystemService::Instance().CreateNewDirectory(newFolderPath.wstring()) == false) {
                         ::MessageBox(_hParent, L"Folder couldn't be created.", L"Error", MB_OK);
                     }
                     break;
@@ -1116,10 +1094,10 @@ BOOL ExplorerDialog::SelectItem(const std::filesystem::path& path)
 
     auto longPath = [](const std::filesystem::path& path) -> std::filesystem::path {
         WCHAR szLongPath[MAX_PATH] = {};
-        WCHAR szRemotePath[MAX_PATH] = {};
+        std::wstring remotePath;
         /* convert possible net path name and get the full path name for compare */
-        if (ConvertNetPathName(path.c_str(), szRemotePath, MAX_PATH) == TRUE) {
-            ::GetLongPathName(szRemotePath, szLongPath, MAX_PATH);
+        if (FileSystemService::Instance().ConvertNetPathName(path.wstring(), remotePath) == TRUE) {
+            ::GetLongPathName(remotePath.c_str(), szLongPath, MAX_PATH);
         }
         else {
             ::GetLongPathName(path.c_str(), szLongPath, MAX_PATH);
@@ -1369,17 +1347,7 @@ void ExplorerDialog::onDelete(bool immediate)
         path.pop_back();
     }
 
-    WCHAR szzFrom[MAX_PATH] = {};
-    path.copy(szzFrom, MAX_PATH);
-
-    /* delete folder into recycle bin */
-    SHFILEOPSTRUCT fileOp = {
-        .hwnd   = _hParent,
-        .wFunc  = FO_DELETE,
-        .pFrom  = szzFrom,
-        .fFlags = static_cast<FILEOP_FLAGS>((immediate ? 0 : FOF_ALLOWUNDO)),
-    };
-    SHFileOperation(&fileOp);
+    FileSystemService::Instance().DeleteFiles(_hParent, { path }, immediate);
 }
 
 void ExplorerDialog::onCut()
@@ -1437,24 +1405,25 @@ void ExplorerDialog::onPaste()
  */
 void ExplorerDialog::UpdateRoots()
 {
-    const DWORD driveList = ::GetLogicalDrives();
+    auto drives = FileSystemService::Instance().GetLogicalDrives();
 
     HTREEITEM hCurrentItem = _hTreeCtrl.GetNextItem(TVI_ROOT, TVGN_CHILD);
 
-    WCHAR drivePathName[] = L" :\\";
-
     for (INT i = 0; i < 26; i++) {
         const WCHAR driveLetter = L'A' + i;
-        drivePathName[0] = driveLetter;
+        std::wstring drivePath = L"A:\\";
+        drivePath[0] = driveLetter;
 
-        if (0x01 & (driveList >> i)) {
-            auto volumeInfo = GetVolumeName(drivePathName);
+        auto it = std::find(drives.begin(), drives.end(), drivePath);
+
+        if (it != drives.end()) {
+            auto volumeInfo = FileSystemService::Instance().GetVolumeName(drivePath);
             std::wstring volumeName = std::format(L"{}:", driveLetter);
             bool haveChildren = false;
 
             if (volumeInfo) {
                 volumeName = std::format(L"{}: [{}]", driveLetter, *volumeInfo);
-                haveChildren = HaveChildren(drivePathName);
+                haveChildren = FileSystemService::Instance().HaveChildren(drivePath, _pSettings->IsUseFullTree(), _pSettings->IsShowHidden());
             }
 
             if (hCurrentItem != nullptr) {
@@ -1464,7 +1433,7 @@ void ExplorerDialog::UpdateRoots()
                     int iIconNormal = 0;
                     int iIconSelected = 0;
                     int iIconOverlayed = 0;
-                    ExtractIcons(drivePathName, nullptr, DEVT_DRIVE, &iIconNormal, &iIconSelected, &iIconOverlayed);
+                    ExtractIcons(drivePath.c_str(), nullptr, DEVT_DRIVE, &iIconNormal, &iIconSelected, &iIconOverlayed);
                     _hTreeCtrl.UpdateItem(hCurrentItem, volumeName, iIconNormal, iIconSelected, iIconOverlayed, 0, haveChildren);
                     hCurrentItem = _hTreeCtrl.GetNextItem(hCurrentItem, TVGN_NEXT);
                 }
@@ -1473,7 +1442,7 @@ void ExplorerDialog::UpdateRoots()
                     int iIconNormal = 0;
                     int iIconSelected = 0;
                     int iIconOverlayed = 0;
-                    ExtractIcons(drivePathName, nullptr, DEVT_DRIVE, &iIconNormal, &iIconSelected, &iIconOverlayed);
+                    ExtractIcons(drivePath.c_str(), nullptr, DEVT_DRIVE, &iIconNormal, &iIconSelected, &iIconOverlayed);
                     _hTreeCtrl.UpdateItem(hCurrentItem, volumeName, iIconNormal, iIconSelected, iIconOverlayed, 0, haveChildren);
                     _hTreeCtrl.DeleteChildren(hCurrentItem);
                     hCurrentItem = _hTreeCtrl.GetNextItem(hCurrentItem, TVGN_NEXT);
@@ -1553,7 +1522,7 @@ HTREEITEM ExplorerDialog::InsertChildFolder(const std::wstring& childFolderName,
     /* look if children test id allowed */
     BOOL haveChildren = FALSE;
     if (bChildrenTest == TRUE) {
-        haveChildren = HaveChildren(path);
+        haveChildren = FileSystemService::Instance().HaveChildren(path, _pSettings->IsUseFullTree(), _pSettings->IsShowHidden());
     }
 
     /* insert item */
@@ -1588,47 +1557,41 @@ BOOL ExplorerDialog::FindFolderAfter(LPCTSTR itemName, HTREEITEM pAfterItem)
     return isFound;
 }
 
-void ExplorerDialog::UpdateChildren(const std::wstring &path, HTREEITEM parentItem, BOOL doRecursive)
+void ExplorerDialog::UpdateChildren(const std::wstring& path, HTREEITEM parentItem, BOOL doRecursive)
 {
-    std::wstring findPath = path;
     HTREEITEM    hCurrentItem = _hTreeCtrl.GetNextItem(parentItem, TVGN_CHILD);
 
-    if (findPath.empty()) {
+    if (path.empty()) {
         return;
     }
-    if (findPath.back() != '\\') {
-        findPath.push_back(L'\\');
-    }
-    findPath.push_back(L'*');
 
-    WIN32_FIND_DATA findData = { 0 };
-    HANDLE  hFind = ::FindFirstFile(findPath.c_str(), &findData);
-    if (hFind != INVALID_HANDLE_VALUE) {
+    auto entries = FileSystemService::Instance().GetDirectoryEntries(path, _pSettings->IsUseFullTree(), _pSettings->IsShowHidden());
+
+    if (!entries.empty()) {
         std::vector<FileSystemEntry> folders;
         std::vector<FileSystemEntry> files;
 
         /* find folders */
-        do {
-            if (::IsValidFolder(findData) == TRUE) {
-                folders.emplace_back(findData.cFileName, findData.dwFileAttributes);
+        for (const auto& entry : entries) {
+            if (entry.isDirectory) {
+                folders.push_back(entry);
             }
-            else if (_pSettings->IsUseFullTree() && ::IsValidFile(findData) == TRUE) {
-                files.emplace_back(findData.cFileName, findData.dwFileAttributes);
+            else {
+                files.push_back(entry);
             }
-        } while (::FindNextFile(hFind, &findData));
-        ::FindClose(hFind);
+        }
 
         /* sort data */
         std::sort(folders.begin(), folders.end(), [](const auto& lhs, const auto& rhs) {
             return ::StrCmpLogicalW(lhs.name.c_str(), rhs.name.c_str()) < 0;
         });
-        std::sort(files.begin(), files.end(), [](const auto &lhs, const auto &rhs) {
+        std::sort(files.begin(), files.end(), [](const auto& lhs, const auto& rhs) {
             return ::StrCmpLogicalW(lhs.name.c_str(), rhs.name.c_str()) < 0;
         });
 
         /* update tree */
-        for (const auto *entries : { &folders, &files }) {
-            for (const auto& entry : *entries) {
+        for (const auto* entries_ptr : { &folders, &files }) {
+            for (const auto& entry : *entries_ptr) {
                 std::wstring name = _hTreeCtrl.GetItemText(hCurrentItem);
                 if (!name.empty()) {
                     /* compare current item and the current folder name */
@@ -1658,7 +1621,7 @@ void ExplorerDialog::UpdateChildren(const std::wstring &path, HTREEITEM parentIt
 
                     /* update icons and expandable information */
                     std::wstring currentPath = GetPath(hCurrentItem);
-                    BOOL haveChildren = HaveChildren(currentPath);
+                    BOOL haveChildren = FileSystemService::Instance().HaveChildren(currentPath, _pSettings->IsUseFullTree(), _pSettings->IsShowHidden());
 
                     /* get icons and update item */
                     INT iIconNormal = 0;
@@ -1697,27 +1660,19 @@ void ExplorerDialog::FetchChildren(HTREEITEM parentItem)
 {
     auto parentFolderPath = GetPath(parentItem);
 
-    /* add wildcard */
-    parentFolderPath.append(L"*");
+    auto entries = FileSystemService::Instance().GetDirectoryEntries(parentFolderPath, _pSettings->IsUseFullTree(), _pSettings->IsShowHidden());
 
-    /* find first file */
-    WIN32_FIND_DATA findData = {};
-    HANDLE hFind = ::FindFirstFile(parentFolderPath.c_str(), &findData);
-
-    /* if not found -> exit */
-    if (hFind != INVALID_HANDLE_VALUE) {
+    if (!entries.empty()) {
         std::vector<FileSystemEntry> folders;
         std::vector<FileSystemEntry> files;
-        do {
-            if (::IsValidFolder(findData) == TRUE) {
-                folders.emplace_back(findData.cFileName, findData.dwFileAttributes);
+        for (const auto& entry : entries) {
+            if (entry.isDirectory) {
+                folders.push_back(entry);
             }
-            else if (_pSettings->IsUseFullTree() && ::IsValidFile(findData) == TRUE) {
-                files.emplace_back(findData.cFileName, findData.dwFileAttributes);
+            else {
+                files.push_back(entry);
             }
-        } while (FindNextFile(hFind, &findData));
-
-        ::FindClose(hFind);
+        }
 
         /* sort data */
         std::sort(folders.begin(), folders.end(), [](const auto& lhs, const auto& rhs) {
@@ -1727,8 +1682,8 @@ void ExplorerDialog::FetchChildren(HTREEITEM parentItem)
             return ::StrCmpLogicalW(lhs.name.c_str(), rhs.name.c_str()) < 0;
         });
 
-        for (const auto *entries : { &folders, &files }) {
-            for (const auto& entry : *entries) {
+        for (const auto* entries_ptr : { &folders, &files }) {
+            for (const auto& entry : *entries_ptr) {
                 if (InsertChildFolder(entry.name, parentItem) == nullptr) {
                     break;
                 }
@@ -2112,13 +2067,13 @@ void ExplorerDialog::Open(const std::wstring &path)
         filePath += path;
 
         /* open possible link */
-        WCHAR resolvedPath[MAX_PATH];
-        if (ResolveShortCut(filePath, resolvedPath, MAX_PATH) == S_OK) {
-            if (::PathIsDirectory(resolvedPath) != FALSE) {
+        std::wstring resolvedPath;
+        if (SUCCEEDED(FileSystemService::Instance().ResolveShortCut(filePath, resolvedPath))) {
+            if (::PathIsDirectory(resolvedPath.c_str()) != FALSE) {
                 SelectItem(resolvedPath);
             }
             else {
-                ::SendMessage(_hParent, NPPM_DOOPEN, 0, (LPARAM)resolvedPath);
+                ::SendMessage(_hParent, NPPM_DOOPEN, 0, (LPARAM)resolvedPath.c_str());
             }
         }
         else {

--- a/src/Explorer/FavesDialog.cpp
+++ b/src/Explorer/FavesDialog.cpp
@@ -36,6 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "Editor.h"
 #include "PropDlg.h"
 #include "resource.h"
+#include "FileSystemService.h"
 #include "StringUtil.h"
 #include "ThemeRenderer.h"
 #include "../NppPlugin/menuCmdID.h"
@@ -1328,9 +1329,9 @@ void FavesDialog::OpenLink(FavesItemPtr pElem)
         }
         case FAVES_FILE: {
             /* open possible link */
-            WCHAR pszFilePath[MAX_PATH];
-            if (ResolveShortCut(pElem->Link(), pszFilePath, MAX_PATH) == S_OK) {
-                Editor::Instance().DoOpen(pszFilePath);
+            std::wstring resolvedPath;
+            if (SUCCEEDED(FileSystemService::Instance().ResolveShortCut(pElem->Link(), resolvedPath))) {
+                Editor::Instance().DoOpen(resolvedPath);
             } else {
                 Editor::Instance().DoOpen(pElem->Link());
             }
@@ -1400,7 +1401,7 @@ void FavesDialog::ReadSettings()
 {
     std::filesystem::path favorites_dat(_pSettings->GetConfigDir());
     favorites_dat /= FAVES_DATA;
-    
+
     if (!std::filesystem::exists(favorites_dat)) {
         _model.Clear();
         return;
@@ -1425,4 +1426,3 @@ void FavesDialog::SaveSettings()
         ::MessageBoxA(_hParent, e.what(), "Error", MB_OK | MB_ICONERROR);
     }
 }
-

--- a/src/Explorer/FavesDialog.cpp
+++ b/src/Explorer/FavesDialog.cpp
@@ -1330,7 +1330,7 @@ void FavesDialog::OpenLink(FavesItemPtr pElem)
         case FAVES_FILE: {
             /* open possible link */
             std::wstring resolvedPath;
-            if (FileSystemService::Instance().ResolveShortCut(pElem->Link(), resolvedPath)) {
+            if (FileSystemService::ResolveShortCut(pElem->Link(), resolvedPath)) {
                 Editor::Instance().DoOpen(resolvedPath);
             } else {
                 Editor::Instance().DoOpen(pElem->Link());

--- a/src/Explorer/FavesDialog.cpp
+++ b/src/Explorer/FavesDialog.cpp
@@ -1330,7 +1330,7 @@ void FavesDialog::OpenLink(FavesItemPtr pElem)
         case FAVES_FILE: {
             /* open possible link */
             std::wstring resolvedPath;
-            if (SUCCEEDED(FileSystemService::Instance().ResolveShortCut(pElem->Link(), resolvedPath))) {
+            if (FileSystemService::Instance().ResolveShortCut(pElem->Link(), resolvedPath)) {
                 Editor::Instance().DoOpen(resolvedPath);
             } else {
                 Editor::Instance().DoOpen(pElem->Link());

--- a/src/Explorer/FileList.cpp
+++ b/src/Explorer/FileList.cpp
@@ -848,8 +848,8 @@ void FileList::UpdateList()
             result = lhs.FileSize() - rhs.FileSize();
             break;
         case SubItem::Date: {
-            unsigned __int64 lhsDate = (static_cast<unsigned __int64>(lhs.LastWriteTime().dwHighDateTime) << 32) + lhs.LastWriteTime().dwLowDateTime;
-            unsigned __int64 rhsDate = (static_cast<unsigned __int64>(rhs.LastWriteTime().dwHighDateTime) << 32) + rhs.LastWriteTime().dwLowDateTime;
+            unsigned __int64 lhsDate = lhs.LastWriteTime();
+            unsigned __int64 rhsDate = rhs.LastWriteTime();
             result = lhsDate - rhsDate;
             break;
         }
@@ -864,7 +864,7 @@ void FileList::UpdateList()
         if (!_pSettings->IsAscending()) {
             result *= -1;
         }
-    
+
         return result < 0;
     });
 
@@ -1160,7 +1160,7 @@ BOOL FileList::FindNextItemInList(LPUINT puPos)
 }
 
 
-void FileList::GetSize(INT64 fileSize, std::wstring & str)
+void FileList::GetSize(unsigned __int64 fileSize, std::wstring & str)
 {
     constexpr std::array<const WCHAR*, 4> SIZE_UNITS{ L"bytes", L"KB", L"MB", L"GB"};
 
@@ -1219,11 +1219,15 @@ void FileList::GetSize(INT64 fileSize, std::wstring & str)
     str = ss.str();
 }
 
-void FileList::GetDate(FILETIME ftLastWriteTime, std::wstring & str)
+void FileList::GetDate(unsigned __int64 lastWriteTime, std::wstring & str)
 {
+    FILETIME    ftLastWriteTime;
     FILETIME    ftLocalTime;
     SYSTEMTIME  sysTime;
     WCHAR       TEMP[18];
+
+    ftLastWriteTime.dwLowDateTime = static_cast<DWORD>(lastWriteTime & 0xFFFFFFFF);
+    ftLastWriteTime.dwHighDateTime = static_cast<DWORD>(lastWriteTime >> 32);
 
     FileTimeToLocalFileTime(&ftLastWriteTime, &ftLocalTime);
     FileTimeToSystemTime(&ftLocalTime, &sysTime);

--- a/src/Explorer/FileList.cpp
+++ b/src/Explorer/FileList.cpp
@@ -718,7 +718,7 @@ void FileList::viewPath(const std::wstring& currentDir, BOOL redraw)
     std::vector<FileSystemEntry> vFoldersTemp;
     std::vector<FileSystemEntry> vFilesTemp;
 
-    auto entries = FileSystemService::Instance().GetDirectoryEntries(currentDir, _pSettings->IsShowHidden(), true);
+    auto entries = FileSystemService::GetDirectoryEntries(currentDir, _pSettings->IsShowHidden(), true);
 
     for (const auto& entry : entries) {
         if (entry.IsDirectory()) {
@@ -1127,7 +1127,7 @@ void FileList::onDelete(bool immediate)
     }
 
     if (!filesToDelete.empty()) {
-        FileSystemService::Instance().DeleteFiles(_hParent, filesToDelete, immediate);
+        FileSystemService::DeleteFiles(_hParent, filesToDelete, immediate);
     }
 }
 
@@ -1593,10 +1593,10 @@ bool FileList::doPaste(LPCTSTR pszTo, LPDROPFILES hData, const DWORD& dwEffect)
 
         if (::MessageBox(_hSelf, message.c_str(), L"Explorer", MB_YESNO) == IDYES) {
             if (dwEffect == DROPEFFECT_MOVE) {
-                FileSystemService::Instance().MoveFiles(_hParent, filesFrom, pszTo);
+                FileSystemService::MoveFiles(_hParent, filesFrom, pszTo);
             }
             else {
-                FileSystemService::Instance().CopyFiles(_hParent, filesFrom, pszTo);
+                FileSystemService::CopyFiles(_hParent, filesFrom, pszTo);
             }
 
             ::KillTimer(_hParent, EXT_UPDATEACTIVATEPATH);

--- a/src/Explorer/FileList.cpp
+++ b/src/Explorer/FileList.cpp
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <windows.h>
 #include <algorithm>
 #include <sstream>
+#include <format>
 #include <array>
 #include <cmath>
 #include <cwctype>
@@ -333,12 +334,14 @@ LRESULT FileList::runListProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPa
 
         if (iPos < _uMaxElements) {
             /* test if overlay icon is need to be updated and if it's changed do a redraw */
-            if (_vFileList[iPos].iOverlay == 0) {
-                ExtractIcons(_pSettings->GetCurrentDir().c_str(), _vFileList[iPos].strNameExt.c_str(),
-                    type, &iIcon, &iSelected, &_vFileList[iPos].iOverlay);
+            if (_vFileList[iPos].Overlay() == 0) {
+                int overlay = 0;
+                ExtractIcons(_pSettings->GetCurrentDir().c_str(), _vFileList[iPos].Name().c_str(),
+                    type, &iIcon, &iSelected, &overlay);
+                _vFileList[iPos].SetOverlay(overlay);
             }
 
-            if (_vFileList[iPos].iOverlay != 0) {
+            if (_vFileList[iPos].Overlay() != 0) {
                 ListView_GetSubItemRect(_hSelf, iPos, 0, LVIR_ICON, &rcIcon);
                 ::RedrawWindow(_hSelf, &rcIcon, NULL, TRUE);
             }
@@ -450,7 +453,7 @@ BOOL FileList::notify(WPARAM wParam, LPARAM lParam)
                 lvItem.pszText      = str;
                 lvItem.cchTextMax   = (int)wcslen(str);
             }
-            if (lvItem.mask & LVIF_IMAGE && !_vFileList[lvItem.iItem].isParent) {
+            if (lvItem.mask & LVIF_IMAGE && !_vFileList[lvItem.iItem].IsParent()) {
                 INT iIcon;
                 INT iOverlay;
                 BOOL isHidden;
@@ -458,7 +461,7 @@ BOOL FileList::notify(WPARAM wParam, LPARAM lParam)
                 lvItem.iImage = iIcon;
                 lvItem.state = INDEXTOOVERLAYMASK(iOverlay);
             }
-            if (lvItem.mask & LVIF_STATE && _vFileList[lvItem.iItem].isHidden) {
+            if (lvItem.mask & LVIF_STATE && _vFileList[lvItem.iItem].IsHidden()) {
                 lvItem.state |= LVIS_CUT;
             }
             break;
@@ -466,7 +469,7 @@ BOOL FileList::notify(WPARAM wParam, LPARAM lParam)
         case LVN_COLUMNCLICK: {
             /* store the marked items */
             for (UINT i = 0; i < _uMaxElements; i++) {
-                _vFileList[i].state = ListView_GetItemState(_hSelf, i, LVIS_FOCUSED | LVIS_SELECTED);
+                _vFileList[i].SetState(ListView_GetItemState(_hSelf, i, LVIS_FOCUSED | LVIS_SELECTED));
             }
 
             INT iPos  = ((LPNMLISTVIEW)lParam)->iSubItem;
@@ -482,7 +485,7 @@ BOOL FileList::notify(WPARAM wParam, LPARAM lParam)
 
             /* mark old items */
             for (UINT i = 0; i < _uMaxElements; i++) {
-                ListView_SetItemState(_hSelf, i, _vFileList[i].state, LVIS_FOCUSED | LVIS_SELECTED);
+                ListView_SetItemState(_hSelf, i, _vFileList[i].State(), LVIS_FOCUSED | LVIS_SELECTED);
             }
             break;
         }
@@ -492,9 +495,9 @@ BOOL FileList::notify(WPARAM wParam, LPARAM lParam)
                 UINT i = ListView_GetSelectionMark(_hSelf);
                 if (i != -1) {
                     if (i < _uMaxFolders) {
-                        _context->NavigateTo(_vFileList[i].strName);
+                        _context->NavigateTo(_vFileList[i].Name());
                     } else {
-                        _context->Open(_vFileList[i].strNameExt);
+                        _context->Open(_vFileList[i].Name());
                     }
                 }
                 break;
@@ -539,13 +542,13 @@ BOOL FileList::notify(WPARAM wParam, LPARAM lParam)
             case CDDS_ITEMPREPAINT: {
                 auto index = static_cast<INT>(lpCD->nmcd.dwItemSpec);
                 if (index >= static_cast<INT>(_uMaxFolders)) {
-                    std::wstring strFilePath = _pSettings->GetCurrentDir() + _vFileList[index].strNameExt;
+                    std::wstring strFilePath = _pSettings->GetCurrentDir() + _vFileList[index].Name();
                     if (IsFileOpen(strFilePath) == TRUE) {
                         ::SelectObject(lpCD->nmcd.hdc, _pSettings->GetUnderlineFont());
                         ::SetWindowLongPtr(_hParent, DWLP_MSGRESULT, CDRF_NEWFONT);
                     }
                 }
-                if (_vFileList[index].isParent) {
+                if (_vFileList[index].IsParent()) {
                     ::SetWindowLongPtr(_hParent, DWLP_MSGRESULT, CDRF_NOTIFYPOSTPAINT);
                 }
                 return TRUE;
@@ -595,7 +598,7 @@ void FileList::UpdateOverlayIcon()
             LIST_LOCK();
 
             /* step over parent icon */
-            if ((_uMaxFolders != 0) && (_vFileList[0].isParent == FALSE)) {
+            if ((_uMaxFolders != 0) && (_vFileList[0].IsParent() == FALSE)) {
                 i = 1;
             }
 
@@ -629,42 +632,73 @@ void FileList::ReadIconToList(UINT iItem, LPINT piIcon, LPINT piOverlay, LPBOOL 
     INT     iIconSelected   = 0;
     DevType type            = (iItem < _uMaxFolders ? DEVT_DIRECTORY : DEVT_FILE);
 
-    if (_vFileList[iItem].iIcon == -1) {
-        ExtractIcons(_pSettings->GetCurrentDir().c_str(), _vFileList[iItem].strNameExt.c_str(),
-            type, &_vFileList[iItem].iIcon, &iIconSelected, NULL);
+    if (_vFileList[iItem].Icon() == -1) {
+        int icon, overlay;
+        ExtractIcons(_pSettings->GetCurrentDir().c_str(), _vFileList[iItem].Name().c_str(),
+            type, &icon, &iIconSelected, &overlay);
+        _vFileList[iItem].SetIcon(icon);
+        _vFileList[iItem].SetOverlay(overlay);
     }
-    *piIcon     = _vFileList[iItem].iIcon;
-    *piOverlay  = _vFileList[iItem].iOverlay;
-    *pbHidden   = _vFileList[iItem].isHidden;
+    *piIcon     = _vFileList[iItem].Icon();
+    *piOverlay  = _vFileList[iItem].Overlay();
+    *pbHidden   = _vFileList[iItem].IsHidden();
 }
 
 void FileList::ReadArrayToList(LPTSTR szItem, INT iItem ,INT iSubItem)
 {
     /* copy into temp */
     switch (iSubItem) {
-    case SubItem::Name:
-        if ((iItem < (INT)_uMaxFolders) && (_pSettings->IsViewBraces())) {
-            swprintf(szItem, L"[%ls]", _vFileList[iItem].strName.c_str());
+    case SubItem::Name: {
+        std::wstring name = _vFileList[iItem].Name();
+        if (!_vFileList[iItem].IsDirectory() || !_vFileList[iItem].IsParent()) {
+            size_t extBegPos = name.find_last_of(L'.');
+            if (extBegPos != std::wstring::npos && extBegPos > 0 && !_pSettings->IsAddExtToName()) {
+                name = name.substr(0, extBegPos);
+            }
+        }
+
+        if ((iItem < (INT)_uMaxFolders) && (_pSettings->IsViewBraces()) && !_vFileList[iItem].IsParent()) {
+            swprintf(szItem, L"[%ls]", name.c_str());
         }
         else {
-            swprintf(szItem, L"%ls", _vFileList[iItem].strName.c_str());
+            swprintf(szItem, L"%ls", name.c_str());
         }
         break;
-    case SubItem::Extension:
-        if ((iItem < (INT)_uMaxFolders) || (!_pSettings->IsAddExtToName())) {
-            wcscpy(szItem, _vFileList[iItem].strExt.c_str());
-        }
-        else {
+    }
+    case SubItem::Extension: {
+        if ((iItem < (INT)_uMaxFolders) || (_pSettings->IsAddExtToName())) {
             szItem[0] = '\0';
         }
+        else {
+            std::wstring name = _vFileList[iItem].Name();
+            size_t extBegPos = name.find_last_of(L'.');
+            if (extBegPos != std::wstring::npos && extBegPos > 0) {
+                wcscpy(szItem, name.substr(extBegPos + 1).c_str());
+            }
+            else {
+                szItem[0] = '\0';
+            }
+        }
         break;
-    case SubItem::Size:
-        wcscpy(szItem, _vFileList[iItem].strSize.c_str());
+    }
+    case SubItem::Size: {
+        if (_vFileList[iItem].IsDirectory()) {
+            wcscpy(szItem, L"<DIR>");
+        }
+        else {
+            std::wstring strSize;
+            GetSize(_vFileList[iItem].FileSize(), strSize);
+            wcscpy(szItem, strSize.c_str());
+        }
         break;
+    }
     case SubItem::Date:
-    default:
-        wcscpy(szItem, _vFileList[iItem].strDate.c_str());
+    default: {
+        std::wstring strDate;
+        GetDate(_vFileList[iItem].LastWriteTime(), strDate);
+        wcscpy(szItem, strDate.c_str());
         break;
+    }
     }
 }
 
@@ -681,102 +715,32 @@ void FileList::viewPath(const std::wstring& currentDir, BOOL redraw)
     _uMaxElementsOld = _uMaxElements;
 
     /* find every element in folder */
-    std::vector<FileListData> vFoldersTemp;
-    std::vector<FileListData> vFilesTemp;
+    std::vector<FileSystemEntry> vFoldersTemp;
+    std::vector<FileSystemEntry> vFilesTemp;
 
-    std::wstring findName = currentDir;
-    if (findName.back() != L'\\') {
-        findName.push_back(L'\\');
-    }
-    findName.push_back(L'*');
+    auto entries = FileSystemService::Instance().GetDirectoryEntries(currentDir, _pSettings->IsShowHidden(), true);
 
-    WIN32_FIND_DATA Find{};
-    auto* hFind = ::FindFirstFile(findName.c_str(), &Find);
-    if (hFind != INVALID_HANDLE_VALUE) {
-        do {
-            if (_pSettings->IsHideFoldersInFileList() && (Find.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+    for (const auto& entry : entries) {
+        if (entry.IsDirectory()) {
+            if (_pSettings->IsHideFoldersInFileList()) {
                 continue; // Skip directories if hideFoldersInContentView is true
             }
 
-            if (IsValidFolder(Find) == TRUE) {
-                /* get data in order of list elements */
-                FileListData tempData;
-                tempData.isParent = FALSE;
-                tempData.iIcon = -1;
-                tempData.iOverlay = 0;
-                tempData.isDirectory = TRUE;
-                tempData.isHidden = ((Find.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0);
-                tempData.strName = Find.cFileName;
-                tempData.strNameExt = Find.cFileName;
-                tempData.strExt = L"";
-
-                if (_pSettings->IsViewLong()) {
-                    tempData.strSize = L"<DIR>";
-                    tempData.i64Size = 0;
-                    GetDate(Find.ftLastWriteTime, tempData.strDate);
-                    tempData.i64Date = 0;
+            if (entry.IsParent()) {
+                if (PathIsRoot(currentDir.c_str())) {
+                    continue;
                 }
-
-                vFoldersTemp.push_back(tempData);
+                vFoldersTemp.push_back(entry);
             }
-            else if ((IsValidFile(Find) == TRUE) && (_pSettings->GetFileFilter().match(Find.cFileName) == TRUE)) {
-                /* store for correct sorting the complete name (with extension) */
-                FileListData tempData;
-                tempData.strNameExt = Find.cFileName;
-                tempData.isParent = FALSE;
-                tempData.iIcon = -1;
-                tempData.iOverlay = 0;
-                tempData.isDirectory = FALSE;
-                tempData.isHidden = ((Find.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0);
-
-                /* extract name and extension */
-                std::wstring fileName = Find.cFileName;
-                size_t extBegPos = fileName.find_last_of(L'.');
-
-                if (extBegPos != std::wstring::npos && extBegPos > 0) {
-                    tempData.strExt = fileName.substr(extBegPos + 1);
-                    if (_pSettings->IsAddExtToName()) {
-                        tempData.strName = fileName;
-                    }
-                    else {
-                        tempData.strName = fileName.substr(0, extBegPos);
-                    }
-                }
-                else {
-                    tempData.strExt = L"";
-                    tempData.strName = fileName;
-                }
-
-                if (_pSettings->IsViewLong()) {
-                    tempData.i64Size = (((INT64)Find.nFileSizeHigh) << 32) + Find.nFileSizeLow;
-                    GetSize(tempData.i64Size, tempData.strSize);
-                    tempData.i64Date = (((INT64)Find.ftLastWriteTime.dwHighDateTime) << 32) + Find.ftLastWriteTime.dwLowDateTime;
-                    GetDate(Find.ftLastWriteTime, tempData.strDate);
-                }
-
-                vFilesTemp.push_back(tempData);
+            else {
+                /* regular folder */
+                vFoldersTemp.push_back(entry);
             }
-            else if ((IsValidParentFolder(Find) == TRUE) && !PathIsRoot(currentDir.c_str())) {
-                /* if 'Find' is not a folder but a parent one */
-                FileListData tempData;
-                tempData.isParent = TRUE;
-                tempData.isHidden = FALSE;
-                tempData.isDirectory = TRUE;
-                tempData.strName = Find.cFileName;
-                tempData.strNameExt = Find.cFileName;
-                tempData.strExt = L"";
-
-                if (_pSettings->IsViewLong()) {
-                    tempData.strSize = L"<DIR>";
-                    tempData.i64Size = 0;
-                    GetDate(Find.ftLastWriteTime, tempData.strDate);
-                    tempData.i64Date = 0;
-                }
-
-                vFoldersTemp.push_back(tempData);
-            }
-        } while (FindNextFile(hFind, &Find));
-        ::FindClose(hFind);
+        }
+        else if (_pSettings->GetFileFilter().match(entry.Name().c_str())) {
+            /* file */
+            vFilesTemp.push_back(entry);
+        }
     }
 
     /* add current dir to stack */
@@ -824,7 +788,7 @@ void FileList::filterFiles(LPCTSTR currentFilter)
 void FileList::SelectFolder(LPCTSTR filePath)
 {
     for (UINT uFolder = 0; uFolder < _uMaxFolders; uFolder++) {
-        if (_wcsicmp(_vFileList[uFolder].strName.c_str(), filePath) == 0) {
+        if (_wcsicmp(_vFileList[uFolder].Name().c_str(), filePath) == 0) {
             SetFocusItem(uFolder);
             return;
         }
@@ -843,7 +807,7 @@ void FileList::SelectCurFile()
 void FileList::SelectFile(const std::wstring &fileName)
 {
     for (SIZE_T i = _uMaxFolders; i < _uMaxElements; i++) {
-        if (fileName == _vFileList[i].strNameExt) {
+        if (fileName == _vFileList[i].Name()) {
             SetFocusItem(i);
             return;
         }
@@ -852,18 +816,18 @@ void FileList::SelectFile(const std::wstring &fileName)
 
 void FileList::UpdateList()
 {
-    std::sort(_vFileList.begin(), _vFileList.end(), [&](const FileListData& lhs, const FileListData& rhs) {
-        if (lhs.isParent != rhs.isParent) {
-            return lhs.isParent > rhs.isParent;
+    std::sort(_vFileList.begin(), _vFileList.end(), [&](const FileSystemEntry& lhs, const FileSystemEntry& rhs) {
+        if (lhs.IsParent() != rhs.IsParent()) {
+            return lhs.IsParent() > rhs.IsParent();
         }
-        if (lhs.isDirectory != rhs.isDirectory) {
-            return lhs.isDirectory > rhs.isDirectory;
+        if (lhs.IsDirectory() != rhs.IsDirectory()) {
+            return lhs.IsDirectory() > rhs.IsDirectory();
         }
 
-        const int resultNameExt = ::StrCmpLogicalW(lhs.strNameExt.c_str(), rhs.strNameExt.c_str());
+        const int resultNameExt = ::StrCmpLogicalW(lhs.Name().c_str(), rhs.Name().c_str());
         INT64 result = 0;
 
-        if (lhs.isDirectory && rhs.isDirectory) {
+        if (lhs.IsDirectory() && rhs.IsDirectory()) {
             return resultNameExt < 0;
         }
 
@@ -871,15 +835,24 @@ void FileList::UpdateList()
         case SubItem::Name:
             result = resultNameExt;
             break;
-        case SubItem::Extension:
-            result = lhs.strExt.compare(rhs.strExt);
+        case SubItem::Extension: {
+            std::wstring lhsExt, rhsExt;
+            size_t lhsExtPos = lhs.Name().find_last_of(L'.');
+            if (lhsExtPos != std::wstring::npos && lhsExtPos > 0) lhsExt = lhs.Name().substr(lhsExtPos + 1);
+            size_t rhsExtPos = rhs.Name().find_last_of(L'.');
+            if (rhsExtPos != std::wstring::npos && rhsExtPos > 0) rhsExt = rhs.Name().substr(rhsExtPos + 1);
+            result = lhsExt.compare(rhsExt);
             break;
+        }
         case SubItem::Size:
-            result = lhs.i64Size - rhs.i64Size;
+            result = lhs.FileSize() - rhs.FileSize();
             break;
-        case SubItem::Date:
-            result = lhs.i64Date - rhs.i64Date;
+        case SubItem::Date: {
+            unsigned __int64 lhsDate = (static_cast<unsigned __int64>(lhs.LastWriteTime().dwHighDateTime) << 32) + lhs.LastWriteTime().dwLowDateTime;
+            unsigned __int64 rhsDate = (static_cast<unsigned __int64>(rhs.LastWriteTime().dwHighDateTime) << 32) + rhs.LastWriteTime().dwLowDateTime;
+            result = lhsDate - rhsDate;
             break;
+        }
         default:
             break;
         }
@@ -999,7 +972,7 @@ void FileList::ShowContextMenu(std::optional<POINT> screenLocation)
     for (UINT uList = 0; uList < _uMaxElements; uList++) {
         if (ListView_GetItemState(_hSelf, uList, LVIS_SELECTED) == LVIS_SELECTED) {
             if (uList == 0) {
-                if (_vFileList[0].strName == L"..") {
+                if (_vFileList[0].IsParent()) {
                     ListView_SetItemState(_hSelf, uList, 0, 0xFF);
                     isParent = true;
                     continue;
@@ -1007,10 +980,10 @@ void FileList::ShowContextMenu(std::optional<POINT> screenLocation)
             }
 
             if (uList < _uMaxFolders) {
-                paths.push_back(_pSettings->GetCurrentDir() + _vFileList[uList].strName + L"\\");
+                paths.push_back(_pSettings->GetCurrentDir() + _vFileList[uList].Name() + L"\\");
             }
             else {
-                paths.push_back(_pSettings->GetCurrentDir() + _vFileList[uList].strNameExt);
+                paths.push_back(_pSettings->GetCurrentDir() + _vFileList[uList].Name());
             }
         }
     }
@@ -1029,10 +1002,10 @@ void FileList::onLMouseBtnDbl()
 
     if (selRow != -1) {
         if (selRow < _uMaxFolders) {
-            _context->NavigateTo(_vFileList[selRow].strName);
+            _context->NavigateTo(_vFileList[selRow].Name());
         }
         else {
-            _context->Open(_vFileList[selRow].strNameExt);
+            _context->Open(_vFileList[selRow].Name());
         }
     }
 }
@@ -1081,7 +1054,7 @@ void FileList::onSelectAll()
 {
     INT firstRow = 0;
     if (_uMaxFolders != 0) {
-        firstRow = (_vFileList[0].isParent ? 0 : -1);
+        firstRow = (_vFileList[0].IsParent() ? 0 : -1);
     }
 
     for (UINT i = 0; i < _uMaxElements; i++) {
@@ -1146,10 +1119,10 @@ void FileList::onDelete(bool immediate)
 
     for (SIZE_T i = 0; i < _uMaxElements; i++) {
         if (ListView_GetItemState(_hSelf, i, LVIS_SELECTED) == LVIS_SELECTED) {
-            if ((i == 0) && (_vFileList[i].isParent == TRUE)) {
+            if ((i == 0) && (_vFileList[i].IsParent())) {
                 continue;
             }
-            filesToDelete.push_back(_pSettings->GetCurrentDir() + _vFileList[i].strNameExt);
+            filesToDelete.push_back(_pSettings->GetCurrentDir() + _vFileList[i].Name());
         }
     }
 
@@ -1173,7 +1146,7 @@ BOOL FileList::FindNextItemInList(LPUINT puPos)
             i = 0;
         }
 
-        std::wstring lowerFileName = _vFileList[i].strName;
+        std::wstring lowerFileName = _vFileList[i].Name();
         std::transform(lowerFileName.begin(), lowerFileName.end(), lowerFileName.begin(), towlower);
         if (0 == lowerFileName.compare(0, _searchQuery.size(), _searchQuery)) {
             /* string found in any following case */
@@ -1412,7 +1385,7 @@ void FileList::UpdateSelItems()
 
         for (UINT i = 0; i < _uMaxElements; i++) {
             if (ListView_GetItemState(_hSelf, i, LVIS_SELECTED) == LVIS_SELECTED) {
-                _itrPos->vStrItems.push_back(_vFileList[i].strNameExt);
+                _itrPos->vStrItems.push_back(_vFileList[i].Name());
             }
         }
     }
@@ -1424,7 +1397,7 @@ void FileList::SetItems(std::vector<std::wstring> vStrItems)
 
     for (UINT i = 0; i < _uMaxElements; i++) {
         for (UINT itemPos = 0; itemPos < vStrItems.size(); itemPos++) {
-            if (_vFileList[i].strNameExt == vStrItems[itemPos]) {
+            if (_vFileList[i].Name() == vStrItems[itemPos]) {
                 ListView_SetItemState(_hSelf, i, selType, 0xFF);
 
                 /* set first item in view */
@@ -1461,10 +1434,10 @@ void FileList::FolderExChange(CIDropSource* pdsrc, CIDataObject* pdobj, UINT dwE
     /* get buffer size */
     for (SIZE_T i = 0; i < _uMaxElements; i++) {
         if (ListView_GetItemState(_hSelf, i, LVIS_SELECTED) == LVIS_SELECTED) {
-            if ((i == 0) && (_vFileList[i].isParent == TRUE)) {
+            if ((i == 0) && (_vFileList[i].IsParent())) {
                 continue;
             }
-            bufsz += (parsz + _vFileList[i].strNameExt.size() + 1) * sizeof(WCHAR);
+            bufsz += (parsz + _vFileList[i].Name().size() + 1) * sizeof(WCHAR);
         }
     }
 
@@ -1492,12 +1465,12 @@ void FileList::FolderExChange(CIDropSource* pdsrc, CIDataObject* pdobj, UINT dwE
     LPTSTR szPath   = (LPTSTR)&lpDropFileStruct[1];
     for (SIZE_T i = 0; i < _uMaxElements; i++) {
         if (ListView_GetItemState(_hSelf, i, LVIS_SELECTED) == LVIS_SELECTED) {
-            if ((i == 0) && (_vFileList[i].isParent == TRUE)) {
+            if ((i == 0) && (_vFileList[i].IsParent())) {
                 continue;
             }
             wcscpy(&szPath[offset], _pSettings->GetCurrentDir().c_str());
-            wcscpy(&szPath[offset+parsz], _vFileList[i].strNameExt.c_str());
-            offset += parsz + _vFileList[i].strNameExt.size() + 1;
+            wcscpy(&szPath[offset+parsz], _vFileList[i].Name().c_str());
+            offset += parsz + _vFileList[i].Name().size() + 1;
         }
     }
 
@@ -1571,12 +1544,12 @@ bool FileList::OnDrop(FORMATETC* /* pFmtEtc*/, STGMEDIUM& medium, DWORD* pdwEffe
     ::SendMessage(_hSelf, LVM_SUBITEMHITTEST, 0, (LPARAM)&hittest);
 
     if ((UINT)hittest.iItem < _uMaxFolders) {
-        if (_vFileList[hittest.iItem].isParent == TRUE) {
+        if (_vFileList[hittest.iItem].IsParent()) {
             ::PathRemoveFileSpec(pszFilesTo);
             ::PathRemoveFileSpec(pszFilesTo);
         }
         else {
-            ::PathAppend(pszFilesTo, _vFileList[hittest.iItem].strNameExt.c_str());
+            ::PathAppend(pszFilesTo, _vFileList[hittest.iItem].Name().c_str());
         }
     }
 

--- a/src/Explorer/FileList.cpp
+++ b/src/Explorer/FileList.cpp
@@ -20,6 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "FileList.h"
 #include "resource.h"
 #include "FileFilter.h"
+#include "FileSystemService.h"
 
 #include <windows.h>
 #include <algorithm>
@@ -669,16 +670,9 @@ void FileList::ReadArrayToList(LPTSTR szItem, INT iItem ,INT iSubItem)
 
 void FileList::viewPath(const std::wstring& currentDir, BOOL redraw)
 {
-    std::wstring findName = currentDir;
-    if (findName.empty()) {
+    if (currentDir.empty()) {
         return;
     }
-
-    /* add backslash if necessary */
-    if (findName.back() != L'\\') {
-        findName.push_back(L'\\');
-    }
-    findName.push_back(L'*');
 
     /* end thread if it is in run mode */
     ::SetEvent(_hEvent[FL_EVT_INT]);
@@ -687,68 +681,76 @@ void FileList::viewPath(const std::wstring& currentDir, BOOL redraw)
     _uMaxElementsOld = _uMaxElements;
 
     /* find every element in folder */
-    WIN32_FIND_DATA Find{};
-    auto *hFind = ::FindFirstFile(findName.c_str(), &Find);
     std::vector<FileListData> vFoldersTemp;
     std::vector<FileListData> vFilesTemp;
+
+    std::wstring findName = currentDir;
+    if (findName.back() != L'\\') {
+        findName.push_back(L'\\');
+    }
+    findName.push_back(L'*');
+
+    WIN32_FIND_DATA Find{};
+    auto* hFind = ::FindFirstFile(findName.c_str(), &Find);
     if (hFind != INVALID_HANDLE_VALUE) {
-        /* get current filters */
-        FileListData tempData;
         do {
-        if (_pSettings->IsHideFoldersInFileList() && (Find.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+            if (_pSettings->IsHideFoldersInFileList() && (Find.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
                 continue; // Skip directories if hideFoldersInContentView is true
             }
 
             if (IsValidFolder(Find) == TRUE) {
                 /* get data in order of list elements */
-                tempData.isParent       = FALSE;
-                tempData.iIcon          = -1;
-                tempData.iOverlay       = 0;
-                tempData.isDirectory    = TRUE;
-                tempData.isHidden       = ((Find.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0);
-                tempData.strName        = Find.cFileName;
-                tempData.strNameExt     = Find.cFileName;
-                tempData.strExt         = L"";
+                FileListData tempData;
+                tempData.isParent = FALSE;
+                tempData.iIcon = -1;
+                tempData.iOverlay = 0;
+                tempData.isDirectory = TRUE;
+                tempData.isHidden = ((Find.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0);
+                tempData.strName = Find.cFileName;
+                tempData.strNameExt = Find.cFileName;
+                tempData.strExt = L"";
 
                 if (_pSettings->IsViewLong()) {
-                    tempData.strSize    = L"<DIR>";
-                    tempData.i64Size    = 0;
+                    tempData.strSize = L"<DIR>";
+                    tempData.i64Size = 0;
                     GetDate(Find.ftLastWriteTime, tempData.strDate);
-                    tempData.i64Date    = 0;
+                    tempData.i64Date = 0;
                 }
 
                 vFoldersTemp.push_back(tempData);
             }
             else if ((IsValidFile(Find) == TRUE) && (_pSettings->GetFileFilter().match(Find.cFileName) == TRUE)) {
                 /* store for correct sorting the complete name (with extension) */
-                tempData.strNameExt     = Find.cFileName;
-                tempData.isParent       = FALSE;
-                tempData.iIcon          = -1;
-                tempData.iOverlay       = 0;
-                tempData.isDirectory    = FALSE;
-                tempData.isHidden       = ((Find.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0);
+                FileListData tempData;
+                tempData.strNameExt = Find.cFileName;
+                tempData.isParent = FALSE;
+                tempData.iIcon = -1;
+                tempData.iOverlay = 0;
+                tempData.isDirectory = FALSE;
+                tempData.isHidden = ((Find.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0);
 
                 /* extract name and extension */
-                LPTSTR extBeg = wcsrchr(&Find.cFileName[1], '.');
+                std::wstring fileName = Find.cFileName;
+                size_t extBegPos = fileName.find_last_of(L'.');
 
-                if (extBeg != NULL) {
-                    *extBeg = '\0';
-                    tempData.strExt     = &extBeg[1];
+                if (extBegPos != std::wstring::npos && extBegPos > 0) {
+                    tempData.strExt = fileName.substr(extBegPos + 1);
+                    if (_pSettings->IsAddExtToName()) {
+                        tempData.strName = fileName;
+                    }
+                    else {
+                        tempData.strName = fileName.substr(0, extBegPos);
+                    }
                 }
                 else {
-                    tempData.strExt     = L"";
+                    tempData.strExt = L"";
+                    tempData.strName = fileName;
                 }
-
-                if ((_pSettings->IsAddExtToName()) && (extBeg != NULL)) {
-                    *extBeg = '.';
-                }
-                tempData.strName        = Find.cFileName;
-
 
                 if (_pSettings->IsViewLong()) {
-                    tempData.i64Size    = (((INT64)Find.nFileSizeHigh) << 32) + Find.nFileSizeLow;
+                    tempData.i64Size = (((INT64)Find.nFileSizeHigh) << 32) + Find.nFileSizeLow;
                     GetSize(tempData.i64Size, tempData.strSize);
-                    tempData.i64Date    = (((INT64)Find.ftLastWriteTime.dwHighDateTime) << 32) + Find.ftLastWriteTime.dwLowDateTime;
+                    tempData.i64Date = (((INT64)Find.ftLastWriteTime.dwHighDateTime) << 32) + Find.ftLastWriteTime.dwLowDateTime;
                     GetDate(Find.ftLastWriteTime, tempData.strDate);
                 }
 
@@ -756,25 +758,24 @@ void FileList::viewPath(const std::wstring& currentDir, BOOL redraw)
             }
             else if ((IsValidParentFolder(Find) == TRUE) && !PathIsRoot(currentDir.c_str())) {
                 /* if 'Find' is not a folder but a parent one */
-                tempData.isParent       = TRUE;
-                tempData.isHidden       = FALSE;
-                tempData.isDirectory    = TRUE;
-                tempData.strName        = Find.cFileName;
-                tempData.strNameExt     = Find.cFileName;
-                tempData.strExt         = L"";
+                FileListData tempData;
+                tempData.isParent = TRUE;
+                tempData.isHidden = FALSE;
+                tempData.isDirectory = TRUE;
+                tempData.strName = Find.cFileName;
+                tempData.strNameExt = Find.cFileName;
+                tempData.strExt = L"";
 
                 if (_pSettings->IsViewLong()) {
-                    tempData.strSize    = L"<DIR>";
-                    tempData.i64Size    = 0;
+                    tempData.strSize = L"<DIR>";
+                    tempData.i64Size = 0;
                     GetDate(Find.ftLastWriteTime, tempData.strDate);
-                    tempData.i64Date    = 0;
+                    tempData.i64Date = 0;
                 }
 
                 vFoldersTemp.push_back(tempData);
             }
         } while (FindNextFile(hFind, &Find));
-
-        /* close file search */
         ::FindClose(hFind);
     }
 
@@ -1141,31 +1142,20 @@ void FileList::onPaste()
 
 void FileList::onDelete(bool immediate)
 {
-    SIZE_T  lengthPath  = _pSettings->GetCurrentDir().size();
-    UINT    bufSize     = ListView_GetSelectedCount(_hSelf) * MAX_PATH;
-    LPTSTR  lpszFiles   = new WCHAR[bufSize];
-    ::ZeroMemory(lpszFiles, bufSize);
+    std::vector<std::wstring> filesToDelete;
 
-    /* add files to payload and seperate with "\0" */
-    SIZE_T offset = 0;
     for (SIZE_T i = 0; i < _uMaxElements; i++) {
         if (ListView_GetItemState(_hSelf, i, LVIS_SELECTED) == LVIS_SELECTED) {
             if ((i == 0) && (_vFileList[i].isParent == TRUE)) {
                 continue;
             }
-            wcscpy(&lpszFiles[offset], _pSettings->GetCurrentDir().c_str());
-            wcscpy(&lpszFiles[offset+lengthPath], _vFileList[i].strNameExt.c_str());
-            offset += lengthPath + _vFileList[i].strNameExt.size() + 1;
+            filesToDelete.push_back(_pSettings->GetCurrentDir() + _vFileList[i].strNameExt);
         }
     }
 
-    /* delete folder into recycle bin */
-    SHFILEOPSTRUCT fileOp   = {0};
-    fileOp.hwnd             = _hParent;
-    fileOp.pFrom            = lpszFiles;
-    fileOp.fFlags           = (immediate ? 0 : FOF_ALLOWUNDO);
-    fileOp.wFunc            = FO_DELETE;
-    SHFileOperation(&fileOp);
+    if (!filesToDelete.empty()) {
+        FileSystemService::Instance().DeleteFiles(_hParent, filesToDelete, immediate);
+    }
 }
 
 BOOL FileList::FindNextItemInList(LPUINT puPos)
@@ -1595,63 +1585,48 @@ bool FileList::OnDrop(FORMATETC* /* pFmtEtc*/, STGMEDIUM& medium, DWORD* pdwEffe
     return true;
 }
 
-bool FileList::doPaste(LPCTSTR pszTo, LPDROPFILES hData, const DWORD & dwEffect)
+bool FileList::doPaste(LPCTSTR pszTo, LPDROPFILES hData, const DWORD& dwEffect)
 {
     /* get files from and to, to fill struct */
-    UINT    headerSize      = sizeof(DROPFILES);
-    SIZE_T  payloadSize     = ::GlobalSize(hData) - headerSize;
-    LPVOID  pPld            = (LPBYTE)hData + headerSize;
-    LPTSTR  lpszFilesFrom   = nullptr;
+    UINT    headerSize = sizeof(DROPFILES);
+    SIZE_T  payloadSize = ::GlobalSize(hData) - headerSize;
+    LPVOID  pPld = (LPBYTE)hData + headerSize;
+    std::vector<std::wstring> filesFrom;
 
     if (((LPDROPFILES)hData)->fWide == TRUE) {
-        lpszFilesFrom = (LPWSTR)pPld;
+        LPCWSTR p = (LPCWSTR)pPld;
+        while (*p) {
+            filesFrom.push_back(p);
+            p += wcslen(p) + 1;
+        }
     }
     else {
-        lpszFilesFrom = new WCHAR[payloadSize];
-        ::MultiByteToWideChar(CP_ACP, 0, (LPCSTR)pPld, (int)payloadSize, lpszFilesFrom, (int)payloadSize);
+        LPCSTR p = (LPCSTR)pPld;
+        while (*p) {
+            int len = ::MultiByteToWideChar(CP_ACP, 0, p, -1, nullptr, 0);
+            std::wstring wstr(len, L'\0');
+            ::MultiByteToWideChar(CP_ACP, 0, p, -1, &wstr[0], len);
+            wstr.resize(len - 1);
+            filesFrom.push_back(wstr);
+            p += strlen(p) + 1;
+        }
     }
 
-    if (lpszFilesFrom != NULL) {
-        UINT count = 0;
-        SIZE_T length = payloadSize;
-        if (((LPDROPFILES)hData)->fWide == TRUE) {
-            length = payloadSize / 2;
-        }
-        for (UINT i = 0; i < length-1; i++) {
-            if (lpszFilesFrom[i] == '\0') {
-                count++;
-            }
-        }
+    if (!filesFrom.empty()) {
+        const std::wstring message = (dwEffect == DROPEFFECT_MOVE)
+            ? std::format(L"Move {} file(s)/folder(s) to:\n\n{}", filesFrom.size(), pszTo)
+            : std::format(L"Copy {} file(s)/folder(s) to:\n\n{}", filesFrom.size(), pszTo);
 
-        WCHAR text[MAX_PATH + 32];
-        if (dwEffect == DROPEFFECT_MOVE) {
-            swprintf(text, L"Move %d file(s)/folder(s) to:\n\n%ls", count, pszTo);
-        }
-        else {// dwEffect == DROPEFFECT_COPY
-            swprintf(text, L"Copy %d file(s)/folder(s) to:\n\n%ls", count, pszTo);
-        }
-
-        if (::MessageBox(_hSelf, text, L"Explorer", MB_YESNO) == IDYES) {
-            // TODO move or copy the file views into other window in dependency to keystate
-            SHFILEOPSTRUCT fileOp = {};
-            fileOp.hwnd         = _hParent;
-            fileOp.pFrom        = lpszFilesFrom;
-            fileOp.pTo          = pszTo;
-            fileOp.fFlags       = FOF_RENAMEONCOLLISION;
+        if (::MessageBox(_hSelf, message.c_str(), L"Explorer", MB_YESNO) == IDYES) {
             if (dwEffect == DROPEFFECT_MOVE) {
-                fileOp.wFunc    = FO_MOVE;
+                FileSystemService::Instance().MoveFiles(_hParent, filesFrom, pszTo);
             }
             else {
-                fileOp.wFunc    = FO_COPY;
+                FileSystemService::Instance().CopyFiles(_hParent, filesFrom, pszTo);
             }
-            SHFileOperation(&fileOp);
 
             ::KillTimer(_hParent, EXT_UPDATEACTIVATEPATH);
             ::SetTimer(_hParent, EXT_UPDATEACTIVATEPATH, 200, NULL);
-        }
-
-        if (((LPDROPFILES)hData)->fWide == FALSE) {
-            delete [] lpszFilesFrom;
         }
     }
     return true;

--- a/src/Explorer/FileList.cpp
+++ b/src/Explorer/FileList.cpp
@@ -650,7 +650,7 @@ void FileList::ReadArrayToList(LPTSTR szItem, INT iItem ,INT iSubItem)
     switch (iSubItem) {
     case SubItem::Name: {
         std::wstring name = _vFileList[iItem].Name();
-        if (!_vFileList[iItem].IsDirectory() || !_vFileList[iItem].IsParent()) {
+        if (!_vFileList[iItem].IsDirectory()) {
             size_t extBegPos = name.find_last_of(L'.');
             if (extBegPos != std::wstring::npos && extBegPos > 0 && !_pSettings->IsAddExtToName()) {
                 name = name.substr(0, extBegPos);
@@ -848,9 +848,9 @@ void FileList::UpdateList()
             result = lhs.FileSize() - rhs.FileSize();
             break;
         case SubItem::Date: {
-            unsigned __int64 lhsDate = lhs.LastWriteTime();
-            unsigned __int64 rhsDate = rhs.LastWriteTime();
-            result = lhsDate - rhsDate;
+            time_t lhsDate = lhs.LastWriteTime();
+            time_t rhsDate = rhs.LastWriteTime();
+            result = static_cast<INT64>(lhsDate - rhsDate);
             break;
         }
         default:
@@ -1160,7 +1160,7 @@ BOOL FileList::FindNextItemInList(LPUINT puPos)
 }
 
 
-void FileList::GetSize(unsigned __int64 fileSize, std::wstring & str)
+void FileList::GetSize(size_t fileSize, std::wstring & str)
 {
     constexpr std::array<const WCHAR*, 4> SIZE_UNITS{ L"bytes", L"KB", L"MB", L"GB"};
 
@@ -1219,24 +1219,21 @@ void FileList::GetSize(unsigned __int64 fileSize, std::wstring & str)
     str = ss.str();
 }
 
-void FileList::GetDate(unsigned __int64 lastWriteTime, std::wstring & str)
+void FileList::GetDate(time_t lastWriteTime, std::wstring & str)
 {
-    FILETIME    ftLastWriteTime;
-    FILETIME    ftLocalTime;
-    SYSTEMTIME  sysTime;
+    struct tm   tm_time;
     WCHAR       TEMP[18];
 
-    ftLastWriteTime.dwLowDateTime = static_cast<DWORD>(lastWriteTime & 0xFFFFFFFF);
-    ftLastWriteTime.dwHighDateTime = static_cast<DWORD>(lastWriteTime >> 32);
-
-    FileTimeToLocalFileTime(&ftLastWriteTime, &ftLocalTime);
-    FileTimeToSystemTime(&ftLocalTime, &sysTime);
+    if (localtime_s(&tm_time, &lastWriteTime) != 0) {
+        str = L"";
+        return;
+    }
 
     if (_pSettings->GetFmtDate() == DateFmt::DFMT_ENG) {
-        swprintf(TEMP, L"%02d/%02d/%02d %02d:%02d", sysTime.wYear % 100, sysTime.wMonth, sysTime.wDay, sysTime.wHour, sysTime.wMinute);
+        swprintf(TEMP, L"%02d/%02d/%02d %02d:%02d", (tm_time.tm_year + 1900) % 100, tm_time.tm_mon + 1, tm_time.tm_mday, tm_time.tm_hour, tm_time.tm_min);
     }
     else {
-        swprintf(TEMP, L"%02d.%02d.%04d %02d:%02d", sysTime.wDay, sysTime.wMonth, sysTime.wYear, sysTime.wHour, sysTime.wMinute);
+        swprintf(TEMP, L"%02d.%02d.%04d %02d:%02d", tm_time.tm_mday, tm_time.tm_mon + 1, tm_time.tm_year + 1900, tm_time.tm_hour, tm_time.tm_min);
     }
 
     str = TEMP;

--- a/src/Explorer/FileList.h
+++ b/src/Explorer/FileList.h
@@ -148,8 +148,8 @@ protected:
         ListView_SetSelectionMark(_hSelf, item);
     };
 
-    void GetSize(unsigned __int64 size, std::wstring & str);
-    void GetDate(unsigned __int64 lastWriteTime, std::wstring & str);
+    void GetSize(size_t size, std::wstring & str);
+    void GetDate(time_t lastWriteTime, std::wstring & str);
 
 private:    /* for thread */
 

--- a/src/Explorer/FileList.h
+++ b/src/Explorer/FileList.h
@@ -45,23 +45,7 @@ static const WORD DotPattern[] =
     0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF
 };
 
-struct FileListData {
-    BOOL            isParent{};
-    INT             iIcon{};
-    INT             iOverlay{};
-    BOOL            isHidden{};
-    BOOL            isDirectory{};
-    std::wstring    strName{};
-    std::wstring    strExt{};
-    std::wstring    strSize{};
-    std::wstring    strDate{};
-    /* not visible, only for sorting */
-    std::wstring    strNameExt{};
-    INT64           i64Size{};
-    INT64           i64Date{};
-    /* not visible, remember state */
-    UINT            state{};
-};
+#include "FileSystemService.h"
 
 
 class FileList : public Window, public CIDropTarget
@@ -200,7 +184,7 @@ private:    /* for thread */
     SIZE_T                          _uMaxFolders;
     SIZE_T                          _uMaxElements;
     SIZE_T                          _uMaxElementsOld;
-    std::vector<FileListData>       _vFileList;
+    std::vector<FileSystemEntry>    _vFileList;
 
     /* search in list by typing of characters */
     std::wstring                    _searchQuery;

--- a/src/Explorer/FileList.h
+++ b/src/Explorer/FileList.h
@@ -148,8 +148,8 @@ protected:
         ListView_SetSelectionMark(_hSelf, item);
     };
 
-    void GetSize(INT64 size, std::wstring & str);
-    void GetDate(FILETIME ftLastWriteTime, std::wstring & str);
+    void GetSize(unsigned __int64 size, std::wstring & str);
+    void GetDate(unsigned __int64 lastWriteTime, std::wstring & str);
 
 private:    /* for thread */
 

--- a/src/Explorer/FileSystemService.cpp
+++ b/src/Explorer/FileSystemService.cpp
@@ -1,4 +1,6 @@
 #include "FileSystemService.h"
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 #include <shlobj.h>
 #include <shlwapi.h>
 #include <winnetwk.h>
@@ -100,21 +102,22 @@ std::vector<FileSystemEntry> FileSystemService::GetDirectoryEntries(const std::w
             }
 
             unsigned __int64 fileSize = (static_cast<unsigned __int64>(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow;
-            entries.emplace_back(findData.cFileName, findData.dwFileAttributes, fileSize, findData.ftLastWriteTime, isParent);
+            unsigned __int64 lastWriteTime = (static_cast<unsigned __int64>(findData.ftLastWriteTime.dwHighDateTime) << 32) + findData.ftLastWriteTime.dwLowDateTime;
+            entries.emplace_back(findData.cFileName, static_cast<unsigned int>(findData.dwFileAttributes), fileSize, lastWriteTime, isParent);
         } while (::FindNextFile(hFind, &findData));
         ::FindClose(hFind);
     }
     return entries;
 }
 
-HRESULT FileSystemService::CreateNewFile(const std::wstring& filePath)
+bool FileSystemService::CreateNewFile(const std::wstring& filePath)
 {
     HANDLE hFile = ::CreateFile(filePath.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (hFile == INVALID_HANDLE_VALUE) {
-        return HRESULT_FROM_WIN32(::GetLastError());
+        return false;
     }
     ::CloseHandle(hFile);
-    return S_OK;
+    return true;
 }
 
 bool FileSystemService::CreateNewDirectory(const std::wstring& directoryPath)
@@ -122,52 +125,52 @@ bool FileSystemService::CreateNewDirectory(const std::wstring& directoryPath)
     return ::CreateDirectory(directoryPath.c_str(), nullptr) != FALSE;
 }
 
-int FileSystemService::DeleteFiles(HWND hWnd, const std::vector<std::wstring>& paths, bool immediate)
+bool FileSystemService::DeleteFiles(void* hWnd, const std::vector<std::wstring>& paths, bool immediate)
 {
     std::wstring from = ToDoubleNullTerminatedString(paths);
     SHFILEOPSTRUCT fileOp = {
-        .hwnd = hWnd,
+        .hwnd = static_cast<HWND>(hWnd),
         .wFunc = FO_DELETE,
         .pFrom = from.c_str(),
         .pTo = nullptr,
         .fFlags = static_cast<FILEOP_FLAGS>(immediate ? 0 : FOF_ALLOWUNDO),
     };
-    return ::SHFileOperation(&fileOp);
+    return ::SHFileOperation(&fileOp) == 0;
 }
 
-int FileSystemService::CopyFiles(HWND hWnd, const std::vector<std::wstring>& fromPaths, const std::wstring& toPath)
+bool FileSystemService::CopyFiles(void* hWnd, const std::vector<std::wstring>& fromPaths, const std::wstring& toPath)
 {
     std::wstring from = ToDoubleNullTerminatedString(fromPaths);
     std::wstring to = toPath;
     to.push_back(L'\0'); // double null termination for SHFileOperation
 
     SHFILEOPSTRUCT fileOp = {
-        .hwnd = hWnd,
+        .hwnd = static_cast<HWND>(hWnd),
         .wFunc = FO_COPY,
         .pFrom = from.c_str(),
         .pTo = to.c_str(),
         .fFlags = FOF_RENAMEONCOLLISION,
     };
-    return ::SHFileOperation(&fileOp);
+    return ::SHFileOperation(&fileOp) == 0;
 }
 
-int FileSystemService::MoveFiles(HWND hWnd, const std::vector<std::wstring>& fromPaths, const std::wstring& toPath)
+bool FileSystemService::MoveFiles(void* hWnd, const std::vector<std::wstring>& fromPaths, const std::wstring& toPath)
 {
     std::wstring from = ToDoubleNullTerminatedString(fromPaths);
     std::wstring to = toPath;
     to.push_back(L'\0'); // double null termination for SHFileOperation
 
     SHFILEOPSTRUCT fileOp = {
-        .hwnd = hWnd,
+        .hwnd = static_cast<HWND>(hWnd),
         .wFunc = FO_MOVE,
         .pFrom = from.c_str(),
         .pTo = to.c_str(),
         .fFlags = FOF_RENAMEONCOLLISION,
     };
-    return ::SHFileOperation(&fileOp);
+    return ::SHFileOperation(&fileOp) == 0;
 }
 
-BOOL FileSystemService::ConvertNetPathName(const std::wstring& pathName, std::wstring& remotePath)
+bool FileSystemService::ConvertNetPathName(const std::wstring& pathName, std::wstring& remotePath)
 {
     DWORD driveList = ::GetLogicalDrives();
     WCHAR volumeName[3] = L" :";
@@ -194,32 +197,32 @@ BOOL FileSystemService::ConvertNetPathName(const std::wstring& pathName, std::ws
     return FALSE;
 }
 
-HRESULT FileSystemService::ResolveShortCut(const std::wstring& shortcutPath, std::wstring& resolvedPath)
+bool FileSystemService::ResolveShortCut(const std::wstring& shortcutPath, std::wstring& resolvedPath)
 {
     Microsoft::WRL::ComPtr<IShellLink> shellLink;
     HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&shellLink));
-    if (FAILED(hr)) return hr;
+    if (FAILED(hr)) return false;
 
     Microsoft::WRL::ComPtr<IPersistFile> persistFile;
     hr = shellLink.As(&persistFile);
-    if (FAILED(hr)) return hr;
+    if (FAILED(hr)) return false;
 
     hr = persistFile->Load(shortcutPath.c_str(), STGM_READ);
-    if (FAILED(hr)) return hr;
+    if (FAILED(hr)) return false;
 
     hr = shellLink->Resolve(nullptr, SLR_UPDATE);
-    if (FAILED(hr)) return hr;
+    if (FAILED(hr)) return false;
 
     WCHAR szResolvedPath[MAX_PATH];
     hr = shellLink->GetPath(szResolvedPath, MAX_PATH, nullptr, SLGP_RAWPATH);
-    if (FAILED(hr)) return hr;
+    if (FAILED(hr)) return false;
 
     resolvedPath = szResolvedPath;
     if (::PathIsDirectory(szResolvedPath) && resolvedPath.back() != L'\\') {
         resolvedPath.push_back(L'\\');
     }
 
-    return S_OK;
+    return true;
 }
 
 std::wstring FileSystemService::ToDoubleNullTerminatedString(const std::vector<std::wstring>& paths)

--- a/src/Explorer/FileSystemService.cpp
+++ b/src/Explorer/FileSystemService.cpp
@@ -1,8 +1,10 @@
 #include "FileSystemService.h"
 #include <shlobj.h>
 #include <shlwapi.h>
+#include <winnetwk.h>
 #include <wrl/client.h>
 #include <algorithm>
+#include <format>
 
 FileSystemService& FileSystemService::Instance()
 {
@@ -39,6 +41,7 @@ std::optional<std::wstring> FileSystemService::GetVolumeName(const std::wstring&
 bool FileSystemService::HaveChildren(const std::wstring& folderPath, bool useFullTree, bool showHidden)
 {
     std::wstring searchPath = folderPath;
+    if (searchPath.empty()) return false;
     if (searchPath.back() != L'\\') {
         searchPath.append(L"\\");
     }
@@ -70,10 +73,11 @@ bool FileSystemService::HaveChildren(const std::wstring& folderPath, bool useFul
     return hasChildren;
 }
 
-std::vector<FileSystemEntry> FileSystemService::GetDirectoryEntries(const std::wstring& path, bool useFullTree, bool showHidden)
+std::vector<FileSystemEntry> FileSystemService::GetDirectoryEntries(const std::wstring& path, bool showHidden, bool includeParent)
 {
     std::vector<FileSystemEntry> entries;
     std::wstring findPath = path;
+    if (findPath.empty()) return entries;
     if (findPath.back() != L'\\') {
         findPath.push_back(L'\\');
     }
@@ -83,17 +87,20 @@ std::vector<FileSystemEntry> FileSystemService::GetDirectoryEntries(const std::w
     HANDLE hFind = ::FindFirstFile(findPath.c_str(), &findData);
     if (hFind != INVALID_HANDLE_VALUE) {
         do {
-            bool isDirectory = (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
             bool isHidden = (findData.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0;
-            bool isDot = (wcscmp(findData.cFileName, L".") == 0 || wcscmp(findData.cFileName, L"..") == 0);
+            bool isParent = (wcscmp(findData.cFileName, L"..") == 0);
+            bool isCurrent = (wcscmp(findData.cFileName, L".") == 0);
 
-            if (isDot || (isHidden && !showHidden) || findData.cFileName[0] == L'?') {
+            if (isCurrent || (isHidden && !showHidden) || findData.cFileName[0] == L'?') {
                 continue;
             }
 
-            if (isDirectory || useFullTree) {
-                entries.emplace_back(findData.cFileName, findData.dwFileAttributes);
+            if (isParent && !includeParent) {
+                continue;
             }
+
+            unsigned __int64 fileSize = (static_cast<unsigned __int64>(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow;
+            entries.emplace_back(findData.cFileName, findData.dwFileAttributes, fileSize, findData.ftLastWriteTime, isParent);
         } while (::FindNextFile(hFind, &findData));
         ::FindClose(hFind);
     }
@@ -163,7 +170,7 @@ int FileSystemService::MoveFiles(HWND hWnd, const std::vector<std::wstring>& fro
 BOOL FileSystemService::ConvertNetPathName(const std::wstring& pathName, std::wstring& remotePath)
 {
     DWORD driveList = ::GetLogicalDrives();
-    WCHAR volumeName[4] = L" :\\";
+    WCHAR volumeName[3] = L" :";
     WCHAR remoteName[MAX_PATH];
 
     for (INT i = 0; i < 26; ++i) {
@@ -174,7 +181,11 @@ BOOL FileSystemService::ConvertNetPathName(const std::wstring& pathName, std::ws
             if (NO_ERROR == WNetGetConnection(volumeName, remoteName, &dwRemoteLength)) {
                 if (pathName.find(remoteName) == 0) {
                     remotePath = volumeName;
-                    remotePath += pathName.substr(wcslen(remoteName));
+                    std::wstring subPath = pathName.substr(wcslen(remoteName));
+                    if (!subPath.empty() && subPath.front() != L'\\') {
+                        remotePath += L"\\";
+                    }
+                    remotePath += subPath;
                     return TRUE;
                 }
             }

--- a/src/Explorer/FileSystemService.cpp
+++ b/src/Explorer/FileSystemService.cpp
@@ -101,8 +101,11 @@ std::vector<FileSystemEntry> FileSystemService::GetDirectoryEntries(const std::w
                 continue;
             }
 
-            unsigned __int64 fileSize = (static_cast<unsigned __int64>(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow;
-            unsigned __int64 lastWriteTime = (static_cast<unsigned __int64>(findData.ftLastWriteTime.dwHighDateTime) << 32) + findData.ftLastWriteTime.dwLowDateTime;
+            size_t fileSize = (static_cast<unsigned __int64>(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow;
+
+            unsigned __int64 ull = (static_cast<unsigned __int64>(findData.ftLastWriteTime.dwHighDateTime) << 32) + findData.ftLastWriteTime.dwLowDateTime;
+            time_t lastWriteTime = static_cast<time_t>((ull - 116444736000000000ULL) / 10000000ULL);
+
             entries.emplace_back(findData.cFileName, static_cast<unsigned int>(findData.dwFileAttributes), fileSize, lastWriteTime, isParent);
         } while (::FindNextFile(hFind, &findData));
         ::FindClose(hFind);

--- a/src/Explorer/FileSystemService.cpp
+++ b/src/Explorer/FileSystemService.cpp
@@ -8,11 +8,83 @@
 #include <algorithm>
 #include <format>
 
-FileSystemService& FileSystemService::Instance()
+FileSystemEntry::FileSystemEntry(const std::wstring& name, unsigned int attributes, size_t fileSize, time_t lastWriteTime, bool isParent)
+    : _name(name)
+    , _attributes(attributes)
+    , _fileSize(fileSize)
+    , _lastWriteTime(lastWriteTime)
+    , _isParent(isParent)
+    , _iIcon(-1)
+    , _iOverlay(0)
+    , _state(0)
 {
-    static FileSystemService instance;
-    return instance;
 }
+
+const std::wstring& FileSystemEntry::Name() const
+{
+    return _name;
+}
+
+unsigned int FileSystemEntry::Attributes() const
+{
+    return _attributes;
+}
+
+size_t FileSystemEntry::FileSize() const
+{
+    return _fileSize;
+}
+
+time_t FileSystemEntry::LastWriteTime() const
+{
+    return _lastWriteTime;
+}
+
+bool FileSystemEntry::IsDirectory() const
+{
+    return (_attributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+}
+
+bool FileSystemEntry::IsHidden() const
+{
+    return (_attributes & FILE_ATTRIBUTE_HIDDEN) != 0;
+}
+
+bool FileSystemEntry::IsParent() const
+{
+    return _isParent;
+}
+
+int FileSystemEntry::Icon() const
+{
+    return _iIcon;
+}
+
+void FileSystemEntry::SetIcon(int icon) const
+{
+    _iIcon = icon;
+}
+
+int FileSystemEntry::Overlay() const
+{
+    return _iOverlay;
+}
+
+void FileSystemEntry::SetOverlay(int overlay) const
+{
+    _iOverlay = overlay;
+}
+
+unsigned int FileSystemEntry::State() const
+{
+    return _state;
+}
+
+void FileSystemEntry::SetState(unsigned int state) const
+{
+    _state = state;
+}
+
 
 std::vector<std::wstring> FileSystemService::GetLogicalDrives()
 {
@@ -101,7 +173,7 @@ std::vector<FileSystemEntry> FileSystemService::GetDirectoryEntries(const std::w
                 continue;
             }
 
-            size_t fileSize = (static_cast<unsigned __int64>(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow;
+            size_t fileSize = static_cast<size_t>((static_cast<unsigned __int64>(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow);
 
             unsigned __int64 ull = (static_cast<unsigned __int64>(findData.ftLastWriteTime.dwHighDateTime) << 32) + findData.ftLastWriteTime.dwLowDateTime;
             time_t lastWriteTime = static_cast<time_t>((ull - 116444736000000000ULL) / 10000000ULL);
@@ -192,12 +264,12 @@ bool FileSystemService::ConvertNetPathName(const std::wstring& pathName, std::ws
                         remotePath += L"\\";
                     }
                     remotePath += subPath;
-                    return TRUE;
+                    return true;
                 }
             }
         }
     }
-    return FALSE;
+    return false;
 }
 
 bool FileSystemService::ResolveShortCut(const std::wstring& shortcutPath, std::wstring& resolvedPath)

--- a/src/Explorer/FileSystemService.cpp
+++ b/src/Explorer/FileSystemService.cpp
@@ -165,12 +165,14 @@ std::vector<FileSystemEntry> FileSystemService::GetDirectoryEntries(const std::w
             bool isParent = (wcscmp(findData.cFileName, L"..") == 0);
             bool isCurrent = (wcscmp(findData.cFileName, L".") == 0);
 
-            if (isCurrent || (isHidden && !showHidden) || findData.cFileName[0] == L'?') {
-                continue;
+            if (isParent) {
+                if (!includeParent) continue;
+                // Always include parent if requested, even if hidden
             }
-
-            if (isParent && !includeParent) {
-                continue;
+            else {
+                if (isCurrent || (isHidden && !showHidden) || findData.cFileName[0] == L'?') {
+                    continue;
+                }
             }
 
             size_t fileSize = static_cast<size_t>((static_cast<unsigned __int64>(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow);

--- a/src/Explorer/FileSystemService.cpp
+++ b/src/Explorer/FileSystemService.cpp
@@ -1,0 +1,223 @@
+#include "FileSystemService.h"
+#include <shlobj.h>
+#include <shlwapi.h>
+#include <wrl/client.h>
+#include <algorithm>
+
+FileSystemService& FileSystemService::Instance()
+{
+    static FileSystemService instance;
+    return instance;
+}
+
+std::vector<std::wstring> FileSystemService::GetLogicalDrives()
+{
+    std::vector<std::wstring> drives;
+    DWORD driveList = ::GetLogicalDrives();
+    for (int i = 0; i < 26; i++) {
+        if (0x01 & (driveList >> i)) {
+            std::wstring drivePath = L"A:\\";
+            drivePath[0] = static_cast<wchar_t>(L'A' + i);
+            drives.push_back(drivePath);
+        }
+    }
+    return drives;
+}
+
+std::optional<std::wstring> FileSystemService::GetVolumeName(const std::wstring& drivePath)
+{
+    DWORD volumeNameSize = MAX_PATH;
+    std::wstring volumeName(volumeNameSize, L'\0');
+
+    if (::GetVolumeInformation(drivePath.c_str(), &volumeName[0], volumeNameSize, nullptr, nullptr, nullptr, nullptr, 0)) {
+        volumeName.resize(wcslen(volumeName.c_str()));
+        return volumeName;
+    }
+    return std::nullopt;
+}
+
+bool FileSystemService::HaveChildren(const std::wstring& folderPath, bool useFullTree, bool showHidden)
+{
+    std::wstring searchPath = folderPath;
+    if (searchPath.back() != L'\\') {
+        searchPath.append(L"\\");
+    }
+    searchPath.append(L"*");
+
+    WIN32_FIND_DATA findData{};
+    HANDLE hFind = ::FindFirstFile(searchPath.c_str(), &findData);
+    if (hFind == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+
+    bool hasChildren = false;
+    do {
+        bool isDirectory = (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+        bool isHidden = (findData.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0;
+        bool isDot = (wcscmp(findData.cFileName, L".") == 0 || wcscmp(findData.cFileName, L"..") == 0);
+
+        if (isDot || (isHidden && !showHidden) || findData.cFileName[0] == L'?') {
+            continue;
+        }
+
+        if (isDirectory || useFullTree) {
+            hasChildren = true;
+            break;
+        }
+    } while (::FindNextFile(hFind, &findData));
+
+    ::FindClose(hFind);
+    return hasChildren;
+}
+
+std::vector<FileSystemEntry> FileSystemService::GetDirectoryEntries(const std::wstring& path, bool useFullTree, bool showHidden)
+{
+    std::vector<FileSystemEntry> entries;
+    std::wstring findPath = path;
+    if (findPath.back() != L'\\') {
+        findPath.push_back(L'\\');
+    }
+    findPath.push_back(L'*');
+
+    WIN32_FIND_DATA findData{};
+    HANDLE hFind = ::FindFirstFile(findPath.c_str(), &findData);
+    if (hFind != INVALID_HANDLE_VALUE) {
+        do {
+            bool isDirectory = (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+            bool isHidden = (findData.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0;
+            bool isDot = (wcscmp(findData.cFileName, L".") == 0 || wcscmp(findData.cFileName, L"..") == 0);
+
+            if (isDot || (isHidden && !showHidden) || findData.cFileName[0] == L'?') {
+                continue;
+            }
+
+            if (isDirectory || useFullTree) {
+                entries.emplace_back(findData.cFileName, findData.dwFileAttributes);
+            }
+        } while (::FindNextFile(hFind, &findData));
+        ::FindClose(hFind);
+    }
+    return entries;
+}
+
+HRESULT FileSystemService::CreateNewFile(const std::wstring& filePath)
+{
+    HANDLE hFile = ::CreateFile(filePath.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (hFile == INVALID_HANDLE_VALUE) {
+        return HRESULT_FROM_WIN32(::GetLastError());
+    }
+    ::CloseHandle(hFile);
+    return S_OK;
+}
+
+bool FileSystemService::CreateNewDirectory(const std::wstring& directoryPath)
+{
+    return ::CreateDirectory(directoryPath.c_str(), nullptr) != FALSE;
+}
+
+int FileSystemService::DeleteFiles(HWND hWnd, const std::vector<std::wstring>& paths, bool immediate)
+{
+    std::wstring from = ToDoubleNullTerminatedString(paths);
+    SHFILEOPSTRUCT fileOp = {
+        .hwnd = hWnd,
+        .wFunc = FO_DELETE,
+        .pFrom = from.c_str(),
+        .pTo = nullptr,
+        .fFlags = static_cast<FILEOP_FLAGS>(immediate ? 0 : FOF_ALLOWUNDO),
+    };
+    return ::SHFileOperation(&fileOp);
+}
+
+int FileSystemService::CopyFiles(HWND hWnd, const std::vector<std::wstring>& fromPaths, const std::wstring& toPath)
+{
+    std::wstring from = ToDoubleNullTerminatedString(fromPaths);
+    std::wstring to = toPath;
+    to.push_back(L'\0'); // double null termination for SHFileOperation
+
+    SHFILEOPSTRUCT fileOp = {
+        .hwnd = hWnd,
+        .wFunc = FO_COPY,
+        .pFrom = from.c_str(),
+        .pTo = to.c_str(),
+        .fFlags = FOF_RENAMEONCOLLISION,
+    };
+    return ::SHFileOperation(&fileOp);
+}
+
+int FileSystemService::MoveFiles(HWND hWnd, const std::vector<std::wstring>& fromPaths, const std::wstring& toPath)
+{
+    std::wstring from = ToDoubleNullTerminatedString(fromPaths);
+    std::wstring to = toPath;
+    to.push_back(L'\0'); // double null termination for SHFileOperation
+
+    SHFILEOPSTRUCT fileOp = {
+        .hwnd = hWnd,
+        .wFunc = FO_MOVE,
+        .pFrom = from.c_str(),
+        .pTo = to.c_str(),
+        .fFlags = FOF_RENAMEONCOLLISION,
+    };
+    return ::SHFileOperation(&fileOp);
+}
+
+BOOL FileSystemService::ConvertNetPathName(const std::wstring& pathName, std::wstring& remotePath)
+{
+    DWORD driveList = ::GetLogicalDrives();
+    WCHAR volumeName[4] = L" :\\";
+    WCHAR remoteName[MAX_PATH];
+
+    for (INT i = 0; i < 26; ++i) {
+        if (0x01 & (driveList >> i)) {
+            volumeName[0] = static_cast<wchar_t>(L'A' + i);
+
+            DWORD dwRemoteLength = MAX_PATH;
+            if (NO_ERROR == WNetGetConnection(volumeName, remoteName, &dwRemoteLength)) {
+                if (pathName.find(remoteName) == 0) {
+                    remotePath = volumeName;
+                    remotePath += pathName.substr(wcslen(remoteName));
+                    return TRUE;
+                }
+            }
+        }
+    }
+    return FALSE;
+}
+
+HRESULT FileSystemService::ResolveShortCut(const std::wstring& shortcutPath, std::wstring& resolvedPath)
+{
+    Microsoft::WRL::ComPtr<IShellLink> shellLink;
+    HRESULT hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&shellLink));
+    if (FAILED(hr)) return hr;
+
+    Microsoft::WRL::ComPtr<IPersistFile> persistFile;
+    hr = shellLink.As(&persistFile);
+    if (FAILED(hr)) return hr;
+
+    hr = persistFile->Load(shortcutPath.c_str(), STGM_READ);
+    if (FAILED(hr)) return hr;
+
+    hr = shellLink->Resolve(nullptr, SLR_UPDATE);
+    if (FAILED(hr)) return hr;
+
+    WCHAR szResolvedPath[MAX_PATH];
+    hr = shellLink->GetPath(szResolvedPath, MAX_PATH, nullptr, SLGP_RAWPATH);
+    if (FAILED(hr)) return hr;
+
+    resolvedPath = szResolvedPath;
+    if (::PathIsDirectory(szResolvedPath) && resolvedPath.back() != L'\\') {
+        resolvedPath.push_back(L'\\');
+    }
+
+    return S_OK;
+}
+
+std::wstring FileSystemService::ToDoubleNullTerminatedString(const std::vector<std::wstring>& paths)
+{
+    std::wstring result;
+    for (const auto& path : paths) {
+        result += path;
+        result.push_back(L'\0');
+    }
+    result.push_back(L'\0');
+    return result;
+}

--- a/src/Explorer/FileSystemService.h
+++ b/src/Explorer/FileSystemService.h
@@ -6,16 +6,46 @@
 #include <windows.h>
 #include <filesystem>
 
-struct FileSystemEntry {
-    std::wstring name;
-    DWORD attributes;
-    bool isDirectory;
-
-    FileSystemEntry(const std::wstring& name, DWORD attributes)
-        : name(name)
-        , attributes(attributes)
-        , isDirectory((attributes & FILE_ATTRIBUTE_DIRECTORY) != 0)
+class FileSystemEntry {
+public:
+    FileSystemEntry(const std::wstring& name, DWORD attributes, unsigned __int64 fileSize, FILETIME lastWriteTime, bool isParent = false)
+        : _name(name)
+        , _attributes(attributes)
+        , _fileSize(fileSize)
+        , _lastWriteTime(lastWriteTime)
+        , _isParent(isParent)
+        , _iIcon(-1)
+        , _iOverlay(0)
+        , _state(0)
     {}
+
+    const std::wstring& Name() const { return _name; }
+    DWORD Attributes() const { return _attributes; }
+    unsigned __int64 FileSize() const { return _fileSize; }
+    FILETIME LastWriteTime() const { return _lastWriteTime; }
+
+    bool IsDirectory() const { return (_attributes & FILE_ATTRIBUTE_DIRECTORY) != 0; }
+    bool IsHidden() const { return (_attributes & FILE_ATTRIBUTE_HIDDEN) != 0; }
+    bool IsParent() const { return _isParent; }
+
+    // UI specific state
+    int Icon() const { return _iIcon; }
+    void SetIcon(int icon) const { _iIcon = icon; }
+    int Overlay() const { return _iOverlay; }
+    void SetOverlay(int overlay) const { _iOverlay = overlay; }
+    UINT State() const { return _state; }
+    void SetState(UINT state) const { _state = state; }
+
+private:
+    std::wstring _name;
+    DWORD _attributes;
+    unsigned __int64 _fileSize;
+    FILETIME _lastWriteTime;
+    bool _isParent;
+
+    mutable int _iIcon;
+    mutable int _iOverlay;
+    mutable UINT _state;
 };
 
 class FileSystemService {
@@ -26,7 +56,7 @@ public:
     std::optional<std::wstring> GetVolumeName(const std::wstring& drivePath);
 
     bool HaveChildren(const std::wstring& folderPath, bool useFullTree, bool showHidden);
-    std::vector<FileSystemEntry> GetDirectoryEntries(const std::wstring& path, bool useFullTree, bool showHidden);
+    std::vector<FileSystemEntry> GetDirectoryEntries(const std::wstring& path, bool showHidden, bool includeParent = false);
 
     HRESULT CreateNewFile(const std::wstring& filePath);
     bool CreateNewDirectory(const std::wstring& directoryPath);

--- a/src/Explorer/FileSystemService.h
+++ b/src/Explorer/FileSystemService.h
@@ -3,10 +3,11 @@
 #include <string>
 #include <vector>
 #include <optional>
+#include <ctime>
 
 class FileSystemEntry {
 public:
-    FileSystemEntry(const std::wstring& name, unsigned int attributes, unsigned __int64 fileSize, unsigned __int64 lastWriteTime, bool isParent = false)
+    FileSystemEntry(const std::wstring& name, unsigned int attributes, size_t fileSize, time_t lastWriteTime, bool isParent = false)
         : _name(name)
         , _attributes(attributes)
         , _fileSize(fileSize)
@@ -19,8 +20,8 @@ public:
 
     const std::wstring& Name() const { return _name; }
     unsigned int Attributes() const { return _attributes; }
-    unsigned __int64 FileSize() const { return _fileSize; }
-    unsigned __int64 LastWriteTime() const { return _lastWriteTime; }
+    size_t FileSize() const { return _fileSize; }
+    time_t LastWriteTime() const { return _lastWriteTime; }
 
     bool IsDirectory() const { return (_attributes & 0x00000010) != 0; } // FILE_ATTRIBUTE_DIRECTORY
     bool IsHidden() const { return (_attributes & 0x00000002) != 0; }    // FILE_ATTRIBUTE_HIDDEN
@@ -37,8 +38,8 @@ public:
 private:
     std::wstring _name;
     unsigned int _attributes;
-    unsigned __int64 _fileSize;
-    unsigned __int64 _lastWriteTime;
+    size_t _fileSize;
+    time_t _lastWriteTime;
     bool _isParent;
 
     mutable int _iIcon;

--- a/src/Explorer/FileSystemService.h
+++ b/src/Explorer/FileSystemService.h
@@ -7,33 +7,24 @@
 
 class FileSystemEntry {
 public:
-    FileSystemEntry(const std::wstring& name, unsigned int attributes, size_t fileSize, time_t lastWriteTime, bool isParent = false)
-        : _name(name)
-        , _attributes(attributes)
-        , _fileSize(fileSize)
-        , _lastWriteTime(lastWriteTime)
-        , _isParent(isParent)
-        , _iIcon(-1)
-        , _iOverlay(0)
-        , _state(0)
-    {}
+    FileSystemEntry(const std::wstring& name, unsigned int attributes, size_t fileSize, time_t lastWriteTime, bool isParent = false);
 
-    const std::wstring& Name() const { return _name; }
-    unsigned int Attributes() const { return _attributes; }
-    size_t FileSize() const { return _fileSize; }
-    time_t LastWriteTime() const { return _lastWriteTime; }
+    const std::wstring& Name() const;
+    unsigned int Attributes() const;
+    size_t FileSize() const;
+    time_t LastWriteTime() const;
 
-    bool IsDirectory() const { return (_attributes & 0x00000010) != 0; } // FILE_ATTRIBUTE_DIRECTORY
-    bool IsHidden() const { return (_attributes & 0x00000002) != 0; }    // FILE_ATTRIBUTE_HIDDEN
-    bool IsParent() const { return _isParent; }
+    bool IsDirectory() const;
+    bool IsHidden() const;
+    bool IsParent() const;
 
     // UI specific state
-    int Icon() const { return _iIcon; }
-    void SetIcon(int icon) const { _iIcon = icon; }
-    int Overlay() const { return _iOverlay; }
-    void SetOverlay(int overlay) const { _iOverlay = overlay; }
-    unsigned int State() const { return _state; }
-    void SetState(unsigned int state) const { _state = state; }
+    int Icon() const;
+    void SetIcon(int icon) const;
+    int Overlay() const;
+    void SetOverlay(int overlay) const;
+    unsigned int State() const;
+    void SetState(unsigned int state) const;
 
 private:
     std::wstring _name;
@@ -49,29 +40,22 @@ private:
 
 class FileSystemService {
 public:
-    static FileSystemService& Instance();
+    static std::vector<std::wstring> GetLogicalDrives();
+    static std::optional<std::wstring> GetVolumeName(const std::wstring& drivePath);
 
-    std::vector<std::wstring> GetLogicalDrives();
-    std::optional<std::wstring> GetVolumeName(const std::wstring& drivePath);
+    static bool HaveChildren(const std::wstring& folderPath, bool useFullTree, bool showHidden);
+    static std::vector<FileSystemEntry> GetDirectoryEntries(const std::wstring& path, bool showHidden, bool includeParent = false);
 
-    bool HaveChildren(const std::wstring& folderPath, bool useFullTree, bool showHidden);
-    std::vector<FileSystemEntry> GetDirectoryEntries(const std::wstring& path, bool showHidden, bool includeParent = false);
+    static bool CreateNewFile(const std::wstring& filePath);
+    static bool CreateNewDirectory(const std::wstring& directoryPath);
 
-    bool CreateNewFile(const std::wstring& filePath);
-    bool CreateNewDirectory(const std::wstring& directoryPath);
+    static bool DeleteFiles(void* hWnd, const std::vector<std::wstring>& paths, bool immediate);
+    static bool CopyFiles(void* hWnd, const std::vector<std::wstring>& from, const std::wstring& to);
+    static bool MoveFiles(void* hWnd, const std::vector<std::wstring>& from, const std::wstring& to);
 
-    bool DeleteFiles(void* hWnd, const std::vector<std::wstring>& paths, bool immediate);
-    bool CopyFiles(void* hWnd, const std::vector<std::wstring>& from, const std::wstring& to);
-    bool MoveFiles(void* hWnd, const std::vector<std::wstring>& from, const std::wstring& to);
-
-    bool ConvertNetPathName(const std::wstring& pathName, std::wstring& remotePath);
-    bool ResolveShortCut(const std::wstring& shortcutPath, std::wstring& resolvedPath);
+    static bool ConvertNetPathName(const std::wstring& pathName, std::wstring& remotePath);
+    static bool ResolveShortCut(const std::wstring& shortcutPath, std::wstring& resolvedPath);
 
 private:
-    FileSystemService() = default;
-    ~FileSystemService() = default;
-    FileSystemService(const FileSystemService&) = delete;
-    FileSystemService& operator=(const FileSystemService&) = delete;
-
-    std::wstring ToDoubleNullTerminatedString(const std::vector<std::wstring>& paths);
+    static std::wstring ToDoubleNullTerminatedString(const std::vector<std::wstring>& paths);
 };

--- a/src/Explorer/FileSystemService.h
+++ b/src/Explorer/FileSystemService.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <optional>
+#include <windows.h>
+#include <filesystem>
+
+struct FileSystemEntry {
+    std::wstring name;
+    DWORD attributes;
+    bool isDirectory;
+
+    FileSystemEntry(const std::wstring& name, DWORD attributes)
+        : name(name)
+        , attributes(attributes)
+        , isDirectory((attributes & FILE_ATTRIBUTE_DIRECTORY) != 0)
+    {}
+};
+
+class FileSystemService {
+public:
+    static FileSystemService& Instance();
+
+    std::vector<std::wstring> GetLogicalDrives();
+    std::optional<std::wstring> GetVolumeName(const std::wstring& drivePath);
+
+    bool HaveChildren(const std::wstring& folderPath, bool useFullTree, bool showHidden);
+    std::vector<FileSystemEntry> GetDirectoryEntries(const std::wstring& path, bool useFullTree, bool showHidden);
+
+    HRESULT CreateNewFile(const std::wstring& filePath);
+    bool CreateNewDirectory(const std::wstring& directoryPath);
+
+    int DeleteFiles(HWND hWnd, const std::vector<std::wstring>& paths, bool immediate);
+    int CopyFiles(HWND hWnd, const std::vector<std::wstring>& from, const std::wstring& to);
+    int MoveFiles(HWND hWnd, const std::vector<std::wstring>& from, const std::wstring& to);
+
+    BOOL ConvertNetPathName(const std::wstring& pathName, std::wstring& remotePath);
+    HRESULT ResolveShortCut(const std::wstring& shortcutPath, std::wstring& resolvedPath);
+
+private:
+    FileSystemService() = default;
+    ~FileSystemService() = default;
+    FileSystemService(const FileSystemService&) = delete;
+    FileSystemService& operator=(const FileSystemService&) = delete;
+
+    std::wstring ToDoubleNullTerminatedString(const std::vector<std::wstring>& paths);
+};

--- a/src/Explorer/FileSystemService.h
+++ b/src/Explorer/FileSystemService.h
@@ -3,12 +3,10 @@
 #include <string>
 #include <vector>
 #include <optional>
-#include <windows.h>
-#include <filesystem>
 
 class FileSystemEntry {
 public:
-    FileSystemEntry(const std::wstring& name, DWORD attributes, unsigned __int64 fileSize, FILETIME lastWriteTime, bool isParent = false)
+    FileSystemEntry(const std::wstring& name, unsigned int attributes, unsigned __int64 fileSize, unsigned __int64 lastWriteTime, bool isParent = false)
         : _name(name)
         , _attributes(attributes)
         , _fileSize(fileSize)
@@ -20,12 +18,12 @@ public:
     {}
 
     const std::wstring& Name() const { return _name; }
-    DWORD Attributes() const { return _attributes; }
+    unsigned int Attributes() const { return _attributes; }
     unsigned __int64 FileSize() const { return _fileSize; }
-    FILETIME LastWriteTime() const { return _lastWriteTime; }
+    unsigned __int64 LastWriteTime() const { return _lastWriteTime; }
 
-    bool IsDirectory() const { return (_attributes & FILE_ATTRIBUTE_DIRECTORY) != 0; }
-    bool IsHidden() const { return (_attributes & FILE_ATTRIBUTE_HIDDEN) != 0; }
+    bool IsDirectory() const { return (_attributes & 0x00000010) != 0; } // FILE_ATTRIBUTE_DIRECTORY
+    bool IsHidden() const { return (_attributes & 0x00000002) != 0; }    // FILE_ATTRIBUTE_HIDDEN
     bool IsParent() const { return _isParent; }
 
     // UI specific state
@@ -33,19 +31,19 @@ public:
     void SetIcon(int icon) const { _iIcon = icon; }
     int Overlay() const { return _iOverlay; }
     void SetOverlay(int overlay) const { _iOverlay = overlay; }
-    UINT State() const { return _state; }
-    void SetState(UINT state) const { _state = state; }
+    unsigned int State() const { return _state; }
+    void SetState(unsigned int state) const { _state = state; }
 
 private:
     std::wstring _name;
-    DWORD _attributes;
+    unsigned int _attributes;
     unsigned __int64 _fileSize;
-    FILETIME _lastWriteTime;
+    unsigned __int64 _lastWriteTime;
     bool _isParent;
 
     mutable int _iIcon;
     mutable int _iOverlay;
-    mutable UINT _state;
+    mutable unsigned int _state;
 };
 
 class FileSystemService {
@@ -58,15 +56,15 @@ public:
     bool HaveChildren(const std::wstring& folderPath, bool useFullTree, bool showHidden);
     std::vector<FileSystemEntry> GetDirectoryEntries(const std::wstring& path, bool showHidden, bool includeParent = false);
 
-    HRESULT CreateNewFile(const std::wstring& filePath);
+    bool CreateNewFile(const std::wstring& filePath);
     bool CreateNewDirectory(const std::wstring& directoryPath);
 
-    int DeleteFiles(HWND hWnd, const std::vector<std::wstring>& paths, bool immediate);
-    int CopyFiles(HWND hWnd, const std::vector<std::wstring>& from, const std::wstring& to);
-    int MoveFiles(HWND hWnd, const std::vector<std::wstring>& from, const std::wstring& to);
+    bool DeleteFiles(void* hWnd, const std::vector<std::wstring>& paths, bool immediate);
+    bool CopyFiles(void* hWnd, const std::vector<std::wstring>& from, const std::wstring& to);
+    bool MoveFiles(void* hWnd, const std::vector<std::wstring>& from, const std::wstring& to);
 
-    BOOL ConvertNetPathName(const std::wstring& pathName, std::wstring& remotePath);
-    HRESULT ResolveShortCut(const std::wstring& shortcutPath, std::wstring& resolvedPath);
+    bool ConvertNetPathName(const std::wstring& pathName, std::wstring& remotePath);
+    bool ResolveShortCut(const std::wstring& shortcutPath, std::wstring& resolvedPath);
 
 private:
     FileSystemService() = default;

--- a/src/Explorer/resource.h
+++ b/src/Explorer/resource.h
@@ -6,7 +6,7 @@
 #include "ExplorerResource.h"
 
 // Next default values for new objects
-// 
+//
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NO_MFC                     1


### PR DESCRIPTION
This change introduces a new `FileSystemService` class as a stateless singleton to centralize all disk I/O operations, decoupling them from the UI components.
Key changes:
- Created `FileSystemService` in `src/Explorer/FileSystemService.h` and `src/Explorer/FileSystemService.cpp`.
- Migrated directory scanning, file operations (create, delete, copy, move), drive information, and shell utility functions to `FileSystemService`.
- Refactored `ExplorerDialog`, `FileList`, and `FavesDialog` to use `FileSystemService`.
- Cleaned up redundant functions from `Explorer.cpp`.
- Updated `Explorer.vcxproj` to include new files.
- Restored CRLF line endings for consistency with the project.

---
*PR created automatically by Jules for task [1939071048650355189](https://jules.google.com/task/1939071048650355189) started by @funap*