### PR TITLE
Fix: Expand tree item after async FetchChildren completes

### DIFF
--- a/src/Explorer/ExplorerDialog.cpp
+++ b/src/Explorer/ExplorerDialog.cpp
@@ -2084,6 +2084,11 @@ void ExplorerDialog::OnEntryUpdated(std::shared_ptr<ExplorerEntry> entry) {
                     }
                 }
             }
+
+            if (hItem == _hItemExpand) {
+                _hTreeCtrl.Expand(hItem, TVE_EXPAND);
+                _hItemExpand = nullptr;
+            }
         }
     }
 }


### PR DESCRIPTION
Fix: Expand tree item after async FetchChildren completes

In `ExplorerDialog::OnEntryUpdated`, check if the updated item matches `_hItemExpand` and visually expand the item using `_hTreeCtrl.Expand(hItem, TVE_EXPAND)` after child nodes are fetched asynchronously and inserted.

This resolves the issue where a tree node isn't expanded during a `TVN_ITEMEXPANDING` event when `FetchChildren` is called asynchronously.

---
*PR created automatically by Jules for task [10554662643166909374](https://jules.google.com/task/10554662643166909374) started by @funap*