### PR TITLE
Extract base icons synchronously and overlay icons asynchronously

### DIFF
--- a/src/Explorer/Explorer.cpp
+++ b/src/Explorer/Explorer.cpp
@@ -515,12 +515,12 @@ HIMAGELIST GetSmallImageList(BOOL bSystem)
     return ghImgList;
 }
 
-void ExtractIcons(LPCTSTR currentPath, LPCTSTR fileName, DevType type, LPINT piIconNormal, LPINT piIconSelected, LPINT piIconOverlayed)
+void ExtractIcons(LPCTSTR currentPath, LPCTSTR fileName, DevType type, LPINT piIconNormal, LPINT piIconSelected)
 {
     SHFILEINFO  sfi{};
     SIZE_T      length = wcslen(currentPath) - 1;
     WCHAR       TEMP[MAX_PATH];
-    UINT        stOverlay = (piIconOverlayed ? SHGFI_OVERLAYINDEX : 0);
+    UINT        stOverlay = 0;
 
     wcscpy(TEMP, currentPath);
     if (TEMP[length] == '*') {
@@ -542,15 +542,15 @@ void ExtractIcons(LPCTSTR currentPath, LPCTSTR fileName, DevType type, LPINT piI
                 0,
                 &sfi,
                 sizeof(SHFILEINFO),
-                SHGFI_ICON | SHGFI_SMALLICON | stOverlay);
+                SHGFI_ICON | SHGFI_SMALLICON | SHGFI_USEFILEATTRIBUTES);
             ::DestroyIcon(sfi.hIcon);
 
             ::ZeroMemory(&sfi, sizeof(SHFILEINFO));
             SHGetFileInfo(TEMP,
-                FILE_ATTRIBUTE_NORMAL,
+                ((type == DEVT_DIRECTORY || type == DEVT_DRIVE) ? FILE_ATTRIBUTE_DIRECTORY : FILE_ATTRIBUTE_NORMAL),
                 &sfi,
                 sizeof(SHFILEINFO),
-                SHGFI_ICON | SHGFI_SMALLICON | stOverlay | SHGFI_USEFILEATTRIBUTES);
+                SHGFI_ICON | SHGFI_SMALLICON | SHGFI_USEFILEATTRIBUTES);
 
             /* find drive icon in own image list */
             UINT onPos = 0;
@@ -581,9 +581,7 @@ void ExtractIcons(LPCTSTR currentPath, LPCTSTR fileName, DevType type, LPINT piI
             *piIconNormal   = ICON_FILE;
             *piIconSelected = ICON_FILE;
         }
-        if (piIconOverlayed != nullptr) {
-            *piIconOverlayed = 0;
-        }
+
     }
     else {
         /* get normal and overlayed icon */
@@ -593,42 +591,40 @@ void ExtractIcons(LPCTSTR currentPath, LPCTSTR fileName, DevType type, LPINT piI
                 0,
                 &sfi,
                 sizeof(SHFILEINFO),
-                SHGFI_ICON | SHGFI_SMALLICON | stOverlay);
+                SHGFI_ICON | SHGFI_SMALLICON | SHGFI_USEFILEATTRIBUTES);
             ::DestroyIcon(sfi.hIcon);
 
             if (type == DEVT_DRIVE) {
                 ::ZeroMemory(&sfi, sizeof(SHFILEINFO));
                 SHGetFileInfo(TEMP,
-                    FILE_ATTRIBUTE_NORMAL,
+                    ((type == DEVT_DIRECTORY || type == DEVT_DRIVE) ? FILE_ATTRIBUTE_DIRECTORY : FILE_ATTRIBUTE_NORMAL),
                     &sfi,
                     sizeof(SHFILEINFO),
-                    SHGFI_ICON | SHGFI_SMALLICON | stOverlay | SHGFI_USEFILEATTRIBUTES);
+                    SHGFI_ICON | SHGFI_SMALLICON | SHGFI_USEFILEATTRIBUTES);
                 ::DestroyIcon(sfi.hIcon);
             }
         }
         else {
             ::ZeroMemory(&sfi, sizeof(SHFILEINFO));
             SHGetFileInfo(TEMP,
-                FILE_ATTRIBUTE_NORMAL,
+                ((type == DEVT_DIRECTORY || type == DEVT_DRIVE) ? FILE_ATTRIBUTE_DIRECTORY : FILE_ATTRIBUTE_NORMAL),
                 &sfi,
                 sizeof(SHFILEINFO),
-                SHGFI_ICON | SHGFI_SMALLICON | stOverlay | SHGFI_USEFILEATTRIBUTES);
+                SHGFI_ICON | SHGFI_SMALLICON | SHGFI_USEFILEATTRIBUTES);
             ::DestroyIcon(sfi.hIcon);
         }
 
         *piIconNormal = sfi.iIcon & 0x00ffffff;
-        if (piIconOverlayed != nullptr) {
-            *piIconOverlayed = sfi.iIcon >> 24;
-        }
+
 
         /* get selected (open) icon */
         if (type == DEVT_DIRECTORY) {
             ::ZeroMemory(&sfi, sizeof(SHFILEINFO));
             SHGetFileInfo(TEMP,
-                0,
+                FILE_ATTRIBUTE_DIRECTORY,
                 &sfi,
                 sizeof(SHFILEINFO),
-                SHGFI_SYSICONINDEX | SHGFI_SMALLICON | SHGFI_OPENICON);
+                SHGFI_SYSICONINDEX | SHGFI_SMALLICON | SHGFI_OPENICON | SHGFI_USEFILEATTRIBUTES);
             ::DestroyIcon(sfi.hIcon);
 
             *piIconSelected = sfi.iIcon;
@@ -642,6 +638,54 @@ void ExtractIcons(LPCTSTR currentPath, LPCTSTR fileName, DevType type, LPINT piI
 
 
 // Current docs
+void GetCompleteIcon(LPCTSTR currentPath, LPCTSTR fileName, DevType type, LPINT piIconNormal, LPINT piIconSelected, LPINT piIconOverlayed)
+{
+    SHFILEINFO  sfi{};
+    SIZE_T      length = wcslen(currentPath) - 1;
+    WCHAR       TEMP[MAX_PATH];
+    UINT        stOverlay = (piIconOverlayed ? SHGFI_OVERLAYINDEX : 0);
+
+    wcscpy(TEMP, currentPath);
+    if (TEMP[length] == '*') {
+        TEMP[length] = '\0';
+    }
+    else if (TEMP[length] != '\\') {
+        wcscat(TEMP, L"\\");
+    }
+
+    if (fileName != nullptr) {
+        wcscat(TEMP, fileName);
+    }
+
+    ::ZeroMemory(&sfi, sizeof(SHFILEINFO));
+    SHGetFileInfo(TEMP,
+        0,
+        &sfi,
+        sizeof(SHFILEINFO),
+        SHGFI_ICON | SHGFI_SMALLICON | stOverlay);
+    ::DestroyIcon(sfi.hIcon);
+
+    *piIconNormal = sfi.iIcon & 0x00ffffff;
+    if (piIconOverlayed != nullptr) {
+        *piIconOverlayed = (sfi.iIcon >> 24) & 0xFF;
+    }
+
+    if (type == DEVT_DIRECTORY) {
+        ::ZeroMemory(&sfi, sizeof(SHFILEINFO));
+        SHGetFileInfo(TEMP,
+            0,
+            &sfi,
+            sizeof(SHFILEINFO),
+            SHGFI_SYSICONINDEX | SHGFI_SMALLICON | SHGFI_OPENICON);
+        ::DestroyIcon(sfi.hIcon);
+
+        *piIconSelected = sfi.iIcon;
+    }
+    else {
+        *piIconSelected = *piIconNormal;
+    }
+}
+
 void UpdateDocs()
 {
     g_HSource = Editor::Instance().GetCurrentScintilla();

--- a/src/Explorer/Explorer.h
+++ b/src/Explorer/Explorer.h
@@ -108,7 +108,8 @@ bool IsValidFile(const WIN32_FIND_DATA & Find);
 
 /* Get Image Lists */
 HIMAGELIST GetSmallImageList(BOOL bSystem);
-void ExtractIcons(LPCTSTR currentPath, LPCTSTR fileName, DevType type, LPINT iIconNormal, LPINT iIconSelected, LPINT iIconOverlayed);
+void ExtractIcons(LPCTSTR currentPath, LPCTSTR fileName, DevType type, LPINT iIconNormal, LPINT iIconSelected);
+void GetCompleteIcon(LPCTSTR currentPath, LPCTSTR fileName, DevType type, LPINT piIconNormal, LPINT piIconSelected, LPINT piIconOverlayed);
 
 /* Resolve Links */
 

--- a/src/Explorer/ExplorerDialog.cpp
+++ b/src/Explorer/ExplorerDialog.cpp
@@ -1319,8 +1319,9 @@ void ExplorerDialog::UpdateRoots()
                 int iIconNormal = 0;
                 int iIconSelected = 0;
                 int iIconOverlayed = 0;
-                ExtractIcons(drivePath.c_str(), nullptr, DEVT_DRIVE, &iIconNormal, &iIconSelected, &iIconOverlayed);
-                _hTreeCtrl.UpdateItem(hCurrentItem, volumeName, iIconNormal, iIconSelected, iIconOverlayed, 0, haveChildren);
+                ExtractIcons(drivePath.c_str(), nullptr, DEVT_DRIVE, &iIconNormal, &iIconSelected);
+                _hTreeCtrl.UpdateItem(hCurrentItem, volumeName, iIconNormal, iIconSelected, 0, 0, haveChildren);
+                _workerThread.Enqueue(std::make_unique<TaskGetCompleteIconTree>(_hSelf, this, hCurrentItem, drivePath, DEVT_DRIVE));
                 hCurrentItem = _hTreeCtrl.GetNextItem(hCurrentItem, TVGN_NEXT);
             }
             else if (!currentItemName.empty() && (driveLetter == currentItemName.front())) {
@@ -1328,8 +1329,9 @@ void ExplorerDialog::UpdateRoots()
                 int iIconNormal = 0;
                 int iIconSelected = 0;
                 int iIconOverlayed = 0;
-                ExtractIcons(drivePath.c_str(), nullptr, DEVT_DRIVE, &iIconNormal, &iIconSelected, &iIconOverlayed);
-                _hTreeCtrl.UpdateItem(hCurrentItem, volumeName, iIconNormal, iIconSelected, iIconOverlayed, 0, haveChildren);
+                ExtractIcons(drivePath.c_str(), nullptr, DEVT_DRIVE, &iIconNormal, &iIconSelected);
+                _hTreeCtrl.UpdateItem(hCurrentItem, volumeName, iIconNormal, iIconSelected, 0, 0, haveChildren);
+                _workerThread.Enqueue(std::make_unique<TaskGetCompleteIconTree>(_hSelf, this, hCurrentItem, drivePath, DEVT_DRIVE));
                 _hTreeCtrl.DeleteChildren(hCurrentItem);
                 hCurrentItem = _hTreeCtrl.GetNextItem(hCurrentItem, TVGN_NEXT);
             }
@@ -1407,10 +1409,13 @@ HTREEITEM ExplorerDialog::InsertChildFolder(const std::wstring& childFolderName,
     INT iIconOverlayed  = 0;
 
     /* get icons */
-    ExtractIcons(path.c_str(), nullptr, devType, &iIconNormal, &iIconSelected, &iIconOverlayed);
+    ExtractIcons(path.c_str(), nullptr, devType, &iIconNormal, &iIconSelected);
 
     /* set item */
-    return _hTreeCtrl.InsertItem(childFolderName, iIconNormal, iIconSelected, iIconOverlayed, bHidden, parentItem, insertAfter, haveChildren);
+    HTREEITEM hNewItem = _hTreeCtrl.InsertItem(childFolderName, iIconNormal, iIconSelected, 0, bHidden, parentItem, insertAfter, haveChildren);
+
+    _workerThread.Enqueue(std::make_unique<TaskGetCompleteIconTree>(_hSelf, this, hNewItem, path, devType));
+    return hNewItem;
 }
 
 BOOL ExplorerDialog::FindFolderAfter(LPCTSTR itemName, HTREEITEM pAfterItem)
@@ -1503,10 +1508,12 @@ void ExplorerDialog::UpdateChildren(const std::wstring& path, HTREEITEM parentIt
                     BOOL haveChildren = FileSystemService::HaveChildren(currentPath, _pSettings->IsUseFullTree(), _pSettings->IsShowHidden());
 
                     INT iIconNormal = 0, iIconSelected = 0, iIconOverlayed = 0;
-                    ExtractIcons(currentPath.c_str(), nullptr, DEVT_DIRECTORY, &iIconNormal, &iIconSelected, &iIconOverlayed);
+                    ExtractIcons(currentPath.c_str(), nullptr, DEVT_DIRECTORY, &iIconNormal, &iIconSelected);
 
                     BOOL bHidden = entry.IsHidden();
-                    _hTreeCtrl.UpdateItem(hCurrentItem, name, iIconNormal, iIconSelected, iIconOverlayed, bHidden, haveChildren);
+                    _hTreeCtrl.UpdateItem(hCurrentItem, name, iIconNormal, iIconSelected, 0, bHidden, haveChildren);
+
+                    _workerThread.Enqueue(std::make_unique<TaskGetCompleteIconTree>(_hSelf, this, hCurrentItem, currentPath, DEVT_DIRECTORY));
 
                     if ((doRecursive) && _hTreeCtrl.IsItemExpanded(hCurrentItem)) {
                         UpdateChildren(currentPath, hCurrentItem);
@@ -2090,5 +2097,13 @@ void ExplorerDialog::OnEntryUpdated(std::shared_ptr<ExplorerEntry> entry) {
                 _hItemExpand = nullptr;
             }
         }
+    }
+}
+
+void ExplorerDialog::UpdateTreeItemCompleteIcon(HTREEITEM hItem, int icon, int selIcon, int overlay)
+{
+    int iIconNormal, iIconSelected, iIconOverlayed;
+    if (_hTreeCtrl.GetItemIcons(hItem, &iIconNormal, &iIconSelected, &iIconOverlayed)) {
+        _hTreeCtrl.SetItemIcons(hItem, icon, selIcon, overlay);
     }
 }

--- a/src/Explorer/ExplorerDialog.h
+++ b/src/Explorer/ExplorerDialog.h
@@ -94,6 +94,7 @@ protected:
 
     void UpdateRoots();
     void UpdateAllExpandedItems();
+    void UpdateTreeItemCompleteIcon(HTREEITEM hItem, int icon, int selIcon, int overlay);
     void UpdatePath();
 
     BOOL SelectItem(const std::filesystem::path& path);

--- a/src/Explorer/ExplorerResource.h
+++ b/src/Explorer/ExplorerResource.h
@@ -157,7 +157,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define	   EXX_MESSAGES		 30800
 	#define EXM_CHANGECOMBO					(EXX_MESSAGES + 1)
 	#define EXM_OPENDIR						(EXX_MESSAGES + 2)
-	#define EXM_UPDATE_OVERICON				(EXX_MESSAGES + 6)
+	#define EXM_REDRAW_ITEM				(EXX_MESSAGES + 6)
 	#define EXM_QUERYDROP					(EXX_MESSAGES + 7)
 	#define EXM_DRAGLEAVE					(EXX_MESSAGES + 8)
 	#define	EXM_OPENLINK					(EXX_MESSAGES + 9)

--- a/src/Explorer/ExplorerTasks.cpp
+++ b/src/Explorer/ExplorerTasks.cpp
@@ -51,3 +51,33 @@ void TaskUpdateDirectory::OnCompleted() {
     _entry->SetChildren(_children);
     _model->NotifyEntryUpdated(_entry);
 }
+
+#include "ExplorerDialog.h"
+#include "FileList.h"
+#include "Explorer.h"
+
+TaskGetCompleteIconTree::TaskGetCompleteIconTree(HWND hDlg, ExplorerDialog* dialog, HTREEITEM hItem, const std::wstring& path, DevType type)
+    : _hDlg(hDlg), _dialog(dialog), _hItem(hItem), _path(path), _type(type) {}
+
+void TaskGetCompleteIconTree::Execute() {
+    GetCompleteIcon(_path.c_str(), nullptr, _type, &_iconNormal, &_iconSelected, &_overlay);
+}
+
+void TaskGetCompleteIconTree::OnCompleted() {
+    if (::IsWindow(_hDlg) && _dialog) {
+        _dialog->UpdateTreeItemCompleteIcon(_hItem, _iconNormal, _iconSelected, _overlay);
+    }
+}
+
+TaskGetCompleteIconFileList::TaskGetCompleteIconFileList(HWND hList, FileList* fileList, UINT iItem, const std::wstring& path, const std::wstring& name, DevType type)
+    : _hList(hList), _fileList(fileList), _iItem(iItem), _path(path), _name(name), _type(type) {}
+
+void TaskGetCompleteIconFileList::Execute() {
+    GetCompleteIcon(_path.c_str(), _name.c_str(), _type, &_iconNormal, &_iconSelected, &_overlay);
+}
+
+void TaskGetCompleteIconFileList::OnCompleted() {
+    if (::IsWindow(_hList) && _fileList) {
+        _fileList->SetCompleteIconAsync(_iItem, _name, _iconNormal, _overlay);
+    }
+}

--- a/src/Explorer/ExplorerTasks.h
+++ b/src/Explorer/ExplorerTasks.h
@@ -33,3 +33,43 @@ private:
     Settings* _settings;
     std::vector<std::shared_ptr<ExplorerEntry>> _children;
 };
+
+class ExplorerDialog;
+class FileList;
+
+class TaskGetCompleteIconTree : public IAsyncTask {
+public:
+    TaskGetCompleteIconTree(HWND hDlg, ExplorerDialog* dialog, HTREEITEM hItem, const std::wstring& path, DevType type);
+
+    void Execute() override;
+    void OnCompleted() override;
+
+private:
+    HWND _hDlg;
+    ExplorerDialog* _dialog;
+    HTREEITEM _hItem;
+    std::wstring _path;
+    DevType _type;
+    int _iconNormal{0};
+    int _iconSelected{0};
+    int _overlay{0};
+};
+
+class TaskGetCompleteIconFileList : public IAsyncTask {
+public:
+    TaskGetCompleteIconFileList(HWND hList, FileList* fileList, UINT iItem, const std::wstring& path, const std::wstring& name, DevType type);
+
+    void Execute() override;
+    void OnCompleted() override;
+
+private:
+    HWND _hList;
+    FileList* _fileList;
+    UINT _iItem;
+    std::wstring _path;
+    std::wstring _name;
+    DevType _type;
+    int _iconNormal{0};
+    int _iconSelected{0};
+    int _overlay{0};
+};

--- a/src/Explorer/FavesDialog.cpp
+++ b/src/Explorer/FavesDialog.cpp
@@ -1177,11 +1177,11 @@ void FavesDialog::UpdateLink(HTREEITEM hParentItem)
                 switch (child->Type()) {
                 case FAVES_FOLDER:
                     /* get icons and update item */
-                    ExtractIcons(child->Link().c_str(), nullptr, DEVT_DIRECTORY, &iIconNormal, &iIconSelected, &iIconOverlayed);
+                    ExtractIcons(child->Link().c_str(), nullptr, DEVT_DIRECTORY, &iIconNormal, &iIconSelected);
                     break;
                 case FAVES_FILE:
                     /* get icons and update item */
-                    ExtractIcons(child->Link().c_str(), nullptr, DEVT_FILE, &iIconNormal, &iIconSelected, &iIconOverlayed);
+                    ExtractIcons(child->Link().c_str(), nullptr, DEVT_FILE, &iIconNormal, &iIconSelected);
                     break;
                 case FAVES_SESSION:
                     haveChildren    = (0 != ::SendMessage(_hParent, NPPM_GETNBSESSIONFILES, 0, (LPARAM)child->Link().c_str()));
@@ -1198,10 +1198,10 @@ void FavesDialog::UpdateLink(HTREEITEM hParentItem)
 
             /* update or add new item */
             if (hCurrentItem != nullptr) {
-                _hTreeCtrl.UpdateItem(hCurrentItem, child->Name(), iIconNormal, iIconSelected, iIconOverlayed, 0, haveChildren, child.get());
+                _hTreeCtrl.UpdateItem(hCurrentItem, child->Name(), iIconNormal, iIconSelected, 0, 0, haveChildren, child.get());
             }
             else {
-                hCurrentItem = _hTreeCtrl.InsertItem(child->Name(), iIconNormal, iIconSelected, iIconOverlayed, 0, hParentItem, TVI_LAST, haveChildren, child.get());
+                hCurrentItem = _hTreeCtrl.InsertItem(child->Name(), iIconNormal, iIconSelected, 0, 0, hParentItem, TVI_LAST, haveChildren, child.get());
             }
 
             /* control item expand state and correct if necessary */
@@ -1250,7 +1250,7 @@ void FavesDialog::DrawSessionChildren(HTREEITEM hItem)
         INT iIconSelected = 0;
         INT iIconOverlayed = 0;
         if (::PathFileExists(newItem->Link().c_str())) {
-            ExtractIcons(newItem->Link().c_str(), nullptr, DEVT_FILE, &iIconNormal, &iIconSelected, &iIconOverlayed);
+            ExtractIcons(newItem->Link().c_str(), nullptr, DEVT_FILE, &iIconNormal, &iIconSelected);
         }
         else {
             newItem->Data(FAVES_PARAM_USERIMAGE);
@@ -1258,7 +1258,7 @@ void FavesDialog::DrawSessionChildren(HTREEITEM hItem)
             iIconSelected = iIconNormal;
             hasMissingFile = TRUE;
         }
-        _hTreeCtrl.InsertItem(newItem->Name(), iIconNormal, iIconSelected, iIconOverlayed, 0, hItem, TVI_LAST, FALSE, newItem.get());
+        _hTreeCtrl.InsertItem(newItem->Name(), iIconNormal, iIconSelected, 0, 0, hItem, TVI_LAST, FALSE, newItem.get());
         session->AddChild(std::move(newItem));
     }
 

--- a/src/Explorer/FileList.cpp
+++ b/src/Explorer/FileList.cpp
@@ -324,29 +324,14 @@ LRESULT FileList::runListProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lPa
         }
         break;
     }
-    case EXM_UPDATE_OVERICON:
+    case EXM_REDRAW_ITEM:
     {
-        INT         iIcon       = 0;
-        INT         iSelected   = 0;
-        RECT        rcIcon      = {0};
-        UINT        iPos        = (UINT)wParam;
-        DevType     type        = (DevType)lParam;
+        RECT rcIcon = {0};
+        UINT iPos = (UINT)wParam;
 
         if (iPos < _uMaxElements) {
-            /* test if overlay icon is need to be updated and if it's changed do a redraw */
-            if (_vFileList[iPos].Overlay() == 0) {
-                int overlay = 0;
-                ExtractIcons(_pSettings->GetCurrentDir().c_str(), _vFileList[iPos].Name().c_str(),
-                    type, &iIcon, &iSelected, &overlay);
-                _vFileList[iPos].SetOverlay(overlay);
-            }
-
-            if (_vFileList[iPos].Overlay() != 0) {
-                ListView_GetSubItemRect(_hSelf, iPos, 0, LVIR_ICON, &rcIcon);
-                ::RedrawWindow(_hSelf, &rcIcon, NULL, TRUE);
-            }
-
-            ::SetEvent(_hEvent[FL_EVT_NEXT]);
+            ListView_GetSubItemRect(_hSelf, iPos, 0, LVIR_ICON, &rcIcon);
+            ::RedrawWindow(_hSelf, &rcIcon, NULL, TRUE);
         }
         break;
     }
@@ -607,15 +592,22 @@ void FileList::UpdateOverlayIcon()
         case FL_EVT_NEXT:
             if (::WaitForSingleObject(_hEvent[FL_EVT_INT], 1) == WAIT_TIMEOUT) {
                 if (i < _uMaxFolders) {
-                    ::PostMessage(_hSelf, EXM_UPDATE_OVERICON, i, (LPARAM)DEVT_DIRECTORY);
+                    if (_vFileList[i].Overlay() == 0) {
+                        _context->GetWorkerThread()->Enqueue(std::make_unique<TaskGetCompleteIconFileList>(_hSelf, this, i, _pSettings->GetCurrentDir(), _vFileList[i].Name(), DEVT_DIRECTORY));
+                    }
+                    i++;
+                    ::SetEvent(_hEvent[FL_EVT_NEXT]);
                 }
                 else if (i < _uMaxElements) {
-                    ::PostMessage(_hSelf, EXM_UPDATE_OVERICON, i, (LPARAM)DEVT_FILE);
+                    if (_vFileList[i].Overlay() == 0) {
+                        _context->GetWorkerThread()->Enqueue(std::make_unique<TaskGetCompleteIconFileList>(_hSelf, this, i, _pSettings->GetCurrentDir(), _vFileList[i].Name(), DEVT_FILE));
+                    }
+                    i++;
+                    ::SetEvent(_hEvent[FL_EVT_NEXT]);
                 }
                 else {
                     LIST_UNLOCK();
                 }
-                i++;
             }
             else {
                 ::SetEvent(_hEvent[FL_EVT_INT]);
@@ -633,9 +625,9 @@ void FileList::ReadIconToList(UINT iItem, LPINT piIcon, LPINT piOverlay, LPBOOL 
     DevType type            = (iItem < _uMaxFolders ? DEVT_DIRECTORY : DEVT_FILE);
 
     if (_vFileList[iItem].Icon() == -1) {
-        int icon, overlay;
+        int icon = 0, overlay = 0;
         ExtractIcons(_pSettings->GetCurrentDir().c_str(), _vFileList[iItem].Name().c_str(),
-            type, &icon, &iIconSelected, &overlay);
+            type, &icon, &iIconSelected);
         _vFileList[iItem].SetIcon(icon);
         _vFileList[iItem].SetOverlay(overlay);
     }
@@ -1604,4 +1596,16 @@ bool FileList::doPaste(LPCTSTR pszTo, LPDROPFILES hData, const DWORD& dwEffect)
         }
     }
     return true;
+}
+
+void FileList::SetCompleteIconAsync(UINT iItem, const std::wstring& expectedName, int icon, int overlay) {
+    if (iItem < _uMaxElements) {
+        LIST_LOCK();
+        if (_vFileList[iItem].Name() == expectedName) {
+            _vFileList[iItem].SetIcon(icon);
+            _vFileList[iItem].SetOverlay(overlay);
+            ::PostMessage(_hSelf, EXM_REDRAW_ITEM, iItem, 0);
+        }
+        LIST_UNLOCK();
+    }
 }

--- a/src/Explorer/FileList.h
+++ b/src/Explorer/FileList.h
@@ -87,6 +87,7 @@ public:
     void SetItems(std::vector<std::wstring> vStrItems);
 
     void UpdateOverlayIcon();
+    void SetCompleteIconAsync(UINT iItem, const std::wstring& expectedName, int icon, int overlay);
     void setDefaultOnCharHandler(std::function<BOOL(UINT /* nChar */, UINT /* nRepCnt */, UINT /* nFlags */)> onCharHandler);
 
 

--- a/src/Explorer/PropDlg.cpp
+++ b/src/Explorer/PropDlg.cpp
@@ -423,7 +423,7 @@ void PropDlg::ExpandTreeView(HTREEITEM hParentItem)
             INT iIconNormal     = 0;
             INT iIconSelected   = 0;
             INT iIconOverlayed  = 0;
-            ExtractIcons(child->Name().c_str(), nullptr, DEVT_FILE, &iIconNormal, &iIconSelected, &iIconOverlayed);
+            ExtractIcons(child->Name().c_str(), nullptr, DEVT_FILE, &iIconNormal, &iIconSelected);
             HTREEITEM pCurrentItem = _hTreeCtrl.InsertItem(child->Name(), _iUImgPos, _iUImgPos, 0, 0, hParentItem, TVI_LAST, haveChildren, child.get());
             ExpandTreeView(pCurrentItem);
         }


### PR DESCRIPTION
This patch fulfills the user's request to optimize performance by removing disk I/O from the main thread when updating the UI.

Changes made:
- Updated `ExtractIcons` to skip fetching the overlay and consistently use `SHGFI_USEFILEATTRIBUTES` (handling directories and files properly) to get the base icon without blocking the main thread.
- Created `GetCompleteIcon` to perform the actual disk access to get both the real icon and the overlay icon.
- Created asynchronous tasks `TaskGetCompleteIconTree` and `TaskGetCompleteIconFileList` which invoke `GetCompleteIcon` on a background thread.
- Modified `ExplorerDialog` and `FileList` to enqueue these tasks for nodes/items, dispatching an update back to the UI upon completion via `IsWindow` bounds checks.
- Addressed deadlocking issues with `FileList`'s `FileOverlayThread` by safely decoupling the enqueuing logic from synchronous locking, keeping the thread responsive.

---
*PR created automatically by Jules for task [15012112944634071466](https://jules.google.com/task/15012112944634071466) started by @funap*